### PR TITLE
fix uart pull definitions

### DIFF
--- a/dts/st/f0/stm32f030c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030c6tx-pinctrl.dtsi
@@ -304,13 +304,11 @@
 
 			usart1_rts_pa1: usart1_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -318,40 +316,40 @@
 
 			usart1_rx_pa3: usart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa15: usart1_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa2: usart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa14: usart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f030c8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030c8tx-pinctrl.dtsi
@@ -312,13 +312,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -326,40 +324,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f030cctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030cctx-pinctrl.dtsi
@@ -380,37 +380,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -418,76 +412,76 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f030f4px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030f4px-pinctrl.dtsi
@@ -154,7 +154,6 @@
 
 			usart1_rts_pa1: usart1_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -162,27 +161,26 @@
 
 			usart1_rx_pa3: usart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa2: usart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa14: usart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f030k6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030k6tx-pinctrl.dtsi
@@ -228,13 +228,11 @@
 
 			usart1_rts_pa1: usart1_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -242,40 +240,40 @@
 
 			usart1_rx_pa3: usart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa15: usart1_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa2: usart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa14: usart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f030r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030r8tx-pinctrl.dtsi
@@ -352,13 +352,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -366,40 +364,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f030rctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030rctx-pinctrl.dtsi
@@ -430,43 +430,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -474,121 +467,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f031c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031c(4-6)tx-pinctrl.dtsi
@@ -372,13 +372,11 @@
 
 			usart1_rts_pa1: usart1_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -386,40 +384,40 @@
 
 			usart1_rx_pa3: usart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa15: usart1_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa2: usart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa14: usart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f031e6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031e6yx-pinctrl.dtsi
@@ -242,7 +242,6 @@
 
 			usart1_rts_pa1: usart1_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -250,36 +249,35 @@
 
 			usart1_rx_pa3: usart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa2: usart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa14: usart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f031f(4-6)px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031f(4-6)px-pinctrl.dtsi
@@ -193,7 +193,6 @@
 
 			usart1_rts_pa1: usart1_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -201,27 +200,26 @@
 
 			usart1_rx_pa3: usart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa2: usart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa14: usart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f031g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031g(4-6)ux-pinctrl.dtsi
@@ -278,7 +278,6 @@
 
 			usart1_rts_pa1: usart1_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -286,40 +285,40 @@
 
 			usart1_rx_pa3: usart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa15: usart1_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa2: usart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa14: usart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f031k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031k(4-6)ux-pinctrl.dtsi
@@ -298,13 +298,11 @@
 
 			usart1_rts_pa1: usart1_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -312,40 +310,40 @@
 
 			usart1_rx_pa3: usart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa15: usart1_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa2: usart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa14: usart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f031k6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031k6tx-pinctrl.dtsi
@@ -288,13 +288,11 @@
 
 			usart1_rts_pa1: usart1_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -302,40 +300,40 @@
 
 			usart1_rx_pa3: usart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa15: usart1_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa2: usart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa14: usart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f038c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038c6tx-pinctrl.dtsi
@@ -372,13 +372,11 @@
 
 			usart1_rts_pa1: usart1_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -386,40 +384,40 @@
 
 			usart1_rx_pa3: usart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa15: usart1_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa2: usart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa14: usart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f038e6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038e6yx-pinctrl.dtsi
@@ -242,7 +242,6 @@
 
 			usart1_rts_pa1: usart1_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -250,36 +249,35 @@
 
 			usart1_rx_pa3: usart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa2: usart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa14: usart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f038f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038f6px-pinctrl.dtsi
@@ -177,7 +177,6 @@
 
 			usart1_rts_pa1: usart1_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -185,27 +184,26 @@
 
 			usart1_rx_pa3: usart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa2: usart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa14: usart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f038g6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038g6ux-pinctrl.dtsi
@@ -262,7 +262,6 @@
 
 			usart1_rts_pa1: usart1_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -270,40 +269,40 @@
 
 			usart1_rx_pa3: usart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa15: usart1_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa2: usart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa14: usart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f038k6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038k6ux-pinctrl.dtsi
@@ -298,13 +298,11 @@
 
 			usart1_rts_pa1: usart1_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -312,40 +310,40 @@
 
 			usart1_rx_pa3: usart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa15: usart1_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa2: usart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa14: usart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f042c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042c(4-6)tx-pinctrl.dtsi
@@ -428,13 +428,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -442,40 +440,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f042c(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042c(4-6)ux-pinctrl.dtsi
@@ -428,13 +428,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -442,40 +440,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f042f4px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042f4px-pinctrl.dtsi
@@ -243,7 +243,6 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -251,27 +250,26 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f042f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042f6px-pinctrl.dtsi
@@ -243,7 +243,6 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -251,27 +250,26 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f042g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042g(4-6)ux-pinctrl.dtsi
@@ -330,13 +330,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -344,40 +342,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f042k(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042k(4-6)tx-pinctrl.dtsi
@@ -340,13 +340,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -354,40 +352,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f042k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042k(4-6)ux-pinctrl.dtsi
@@ -340,13 +340,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -354,40 +352,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f042t6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042t6yx-pinctrl.dtsi
@@ -340,13 +340,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -354,40 +352,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f048c6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048c6ux-pinctrl.dtsi
@@ -406,13 +406,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -420,40 +418,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f048g6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048g6ux-pinctrl.dtsi
@@ -296,13 +296,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -310,40 +308,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f048t6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048t6yx-pinctrl.dtsi
@@ -322,13 +322,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -336,40 +334,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f051c4tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c4tx-pinctrl.dtsi
@@ -336,7 +336,6 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -344,22 +343,22 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f051c4ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c4ux-pinctrl.dtsi
@@ -336,7 +336,6 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -344,22 +343,22 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f051c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c6tx-pinctrl.dtsi
@@ -342,13 +342,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -356,40 +354,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f051c6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c6ux-pinctrl.dtsi
@@ -342,13 +342,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -356,40 +354,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f051c8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c8tx-pinctrl.dtsi
@@ -386,13 +386,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -400,40 +398,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f051c8ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c8ux-pinctrl.dtsi
@@ -386,13 +386,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -400,40 +398,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f051k4tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k4tx-pinctrl.dtsi
@@ -284,7 +284,6 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -292,22 +291,22 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f051k4ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k4ux-pinctrl.dtsi
@@ -294,7 +294,6 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -302,22 +301,22 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f051k6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k6tx-pinctrl.dtsi
@@ -290,13 +290,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -304,40 +302,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f051k6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k6ux-pinctrl.dtsi
@@ -300,13 +300,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -314,40 +312,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f051k8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k8tx-pinctrl.dtsi
@@ -290,13 +290,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -304,40 +302,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f051k8ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k8ux-pinctrl.dtsi
@@ -300,13 +300,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -314,40 +312,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f051r4tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r4tx-pinctrl.dtsi
@@ -396,7 +396,6 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -404,22 +403,22 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f051r6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r6tx-pinctrl.dtsi
@@ -402,13 +402,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -416,40 +414,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f051r8hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r8hx-pinctrl.dtsi
@@ -426,13 +426,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -440,40 +438,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f051r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r8tx-pinctrl.dtsi
@@ -426,13 +426,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -440,40 +438,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f051t8yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051t8yx-pinctrl.dtsi
@@ -290,13 +290,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -304,40 +302,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f058c8ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058c8ux-pinctrl.dtsi
@@ -386,13 +386,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -400,40 +398,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f058r8hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058r8hx-pinctrl.dtsi
@@ -426,13 +426,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -440,40 +438,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f058r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058r8tx-pinctrl.dtsi
@@ -426,13 +426,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -440,40 +438,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f058t8yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058t8yx-pinctrl.dtsi
@@ -290,13 +290,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -304,40 +302,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f070c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070c6tx-pinctrl.dtsi
@@ -272,13 +272,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -286,40 +284,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f070cbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070cbtx-pinctrl.dtsi
@@ -344,31 +344,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -376,58 +371,58 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f070f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070f6px-pinctrl.dtsi
@@ -182,13 +182,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -196,27 +194,26 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f070rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070rbtx-pinctrl.dtsi
@@ -394,37 +394,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -432,85 +426,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f071c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071c(8-b)tx-pinctrl.dtsi
@@ -444,31 +444,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -476,58 +471,58 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f071c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071c(8-b)ux-pinctrl.dtsi
@@ -444,31 +444,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -476,58 +471,58 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f071cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071cbyx-pinctrl.dtsi
@@ -444,31 +444,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -476,58 +471,58 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f071rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071rbtx-pinctrl.dtsi
@@ -498,37 +498,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -536,85 +530,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f071v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071v(8-b)hx-pinctrl.dtsi
@@ -636,49 +636,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -686,103 +678,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f071v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071v(8-b)tx-pinctrl.dtsi
@@ -636,49 +636,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -686,103 +678,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f072c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072c(8-b)tx-pinctrl.dtsi
@@ -466,31 +466,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -498,58 +493,58 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f072c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072c(8-b)ux-pinctrl.dtsi
@@ -466,31 +466,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -498,58 +493,58 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f072cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072cbyx-pinctrl.dtsi
@@ -466,31 +466,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -498,58 +493,58 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f072r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072r(8-b)tx-pinctrl.dtsi
@@ -520,37 +520,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -558,85 +552,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f072rbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072rbhx-pinctrl.dtsi
@@ -520,37 +520,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -558,85 +552,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f072rbix-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072rbix-pinctrl.dtsi
@@ -520,37 +520,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -558,85 +552,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f072v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072v(8-b)hx-pinctrl.dtsi
@@ -667,49 +667,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -717,103 +709,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f072v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072v(8-b)tx-pinctrl.dtsi
@@ -667,49 +667,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -717,103 +709,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f078cbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbtx-pinctrl.dtsi
@@ -444,31 +444,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -476,58 +471,58 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f078cbux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbux-pinctrl.dtsi
@@ -444,31 +444,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -476,58 +471,58 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f078cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbyx-pinctrl.dtsi
@@ -444,31 +444,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -476,58 +471,58 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f078rbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078rbhx-pinctrl.dtsi
@@ -498,37 +498,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -536,85 +530,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f078rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078rbtx-pinctrl.dtsi
@@ -498,37 +498,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -536,85 +530,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f078vbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078vbhx-pinctrl.dtsi
@@ -636,49 +636,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -686,103 +678,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f078vbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078vbtx-pinctrl.dtsi
@@ -636,49 +636,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -686,103 +678,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f0/stm32f091c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091c(b-c)tx-pinctrl.dtsi
@@ -502,37 +502,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -540,76 +534,76 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f091c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091c(b-c)ux-pinctrl.dtsi
@@ -502,37 +502,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -540,76 +534,76 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f091r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091r(b-c)tx-pinctrl.dtsi
@@ -556,43 +556,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -600,157 +593,157 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pc1: usart7_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pc7: usart7_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pc3: usart8_rx_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pc9: usart8_rx_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pc0: usart7_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pc6: usart7_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pc2: usart8_tx_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pc8: usart8_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f091rchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091rchx-pinctrl.dtsi
@@ -556,43 +556,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -600,157 +593,157 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pc1: usart7_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pc7: usart7_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pc3: usart8_rx_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pc9: usart8_rx_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pc0: usart7_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pc6: usart7_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pc2: usart8_tx_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pc8: usart8_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f091rcyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091rcyx-pinctrl.dtsi
@@ -556,43 +556,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -600,157 +593,157 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pc1: usart7_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pc7: usart7_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pc3: usart8_rx_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pc9: usart8_rx_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pc0: usart7_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pc6: usart7_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pc2: usart8_tx_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pc8: usart8_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f091v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091v(b-c)tx-pinctrl.dtsi
@@ -703,85 +703,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pf3: usart6_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart7_rts_pd15: usart7_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart7_rts_pf2: usart7_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart8_rts_pd12: usart8_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -789,220 +775,220 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pf10: usart6_rx_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pc1: usart7_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pc7: usart7_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pf3: usart7_rx_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pc3: usart8_rx_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pc9: usart8_rx_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF1)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pd14: usart8_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pf9: usart6_tx_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pc0: usart7_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pc6: usart7_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pf2: usart7_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pc2: usart8_tx_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pc8: usart8_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pd13: usart8_tx_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f091vchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091vchx-pinctrl.dtsi
@@ -703,85 +703,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pf3: usart6_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart7_rts_pd15: usart7_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart7_rts_pf2: usart7_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart8_rts_pd12: usart8_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -789,220 +775,220 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pf10: usart6_rx_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pc1: usart7_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pc7: usart7_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pf3: usart7_rx_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pc3: usart8_rx_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pc9: usart8_rx_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF1)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pd14: usart8_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pf9: usart6_tx_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pc0: usart7_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pc6: usart7_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pf2: usart7_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pc2: usart8_tx_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pc8: usart8_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pd13: usart8_tx_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f098cctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098cctx-pinctrl.dtsi
@@ -502,37 +502,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -540,76 +534,76 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f098ccux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098ccux-pinctrl.dtsi
@@ -502,37 +502,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -540,76 +534,76 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f098rchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rchx-pinctrl.dtsi
@@ -556,43 +556,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -600,157 +593,157 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pc1: usart7_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pc7: usart7_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pc3: usart8_rx_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pc9: usart8_rx_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pc0: usart7_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pc6: usart7_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pc2: usart8_tx_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pc8: usart8_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f098rctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rctx-pinctrl.dtsi
@@ -556,43 +556,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -600,157 +593,157 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pc1: usart7_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pc7: usart7_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pc3: usart8_rx_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pc9: usart8_rx_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pc0: usart7_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pc6: usart7_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pc2: usart8_tx_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pc8: usart8_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f098rcyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rcyx-pinctrl.dtsi
@@ -556,43 +556,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -600,157 +593,157 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pc1: usart7_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pc7: usart7_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pc3: usart8_rx_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pc9: usart8_rx_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pc0: usart7_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pc6: usart7_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pc2: usart8_tx_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pc8: usart8_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f098vchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098vchx-pinctrl.dtsi
@@ -703,85 +703,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pf3: usart6_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart7_rts_pd15: usart7_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart7_rts_pf2: usart7_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart8_rts_pd12: usart8_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -789,220 +775,220 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pf10: usart6_rx_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pc1: usart7_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pc7: usart7_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pf3: usart7_rx_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pc3: usart8_rx_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pc9: usart8_rx_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF1)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pd14: usart8_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pf9: usart6_tx_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pc0: usart7_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pc6: usart7_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pf2: usart7_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pc2: usart8_tx_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pc8: usart8_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pd13: usart8_tx_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f0/stm32f098vctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098vctx-pinctrl.dtsi
@@ -703,85 +703,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pf3: usart6_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart7_rts_pd15: usart7_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart7_rts_pf2: usart7_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart8_rts_pd12: usart8_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -789,220 +775,220 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF1)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF2)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF2)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pf10: usart6_rx_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pc1: usart7_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pc7: usart7_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF1)>;
+				bias-pull-up;
 			};
 
 			usart7_rx_pf3: usart7_rx_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pc3: usart8_rx_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pc9: usart8_rx_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF1)>;
+				bias-pull-up;
 			};
 
 			usart8_rx_pd14: usart8_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF1)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF5)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF2)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pf9: usart6_tx_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pc0: usart7_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pc6: usart7_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			usart7_tx_pf2: usart7_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pc2: usart8_tx_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF2)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pc8: usart8_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF1)>;
-				bias-pull-up;
 			};
 
 			usart8_tx_pd13: usart8_tx_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f1/stm32f100c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100c(4-6)tx-pinctrl.dtsi
@@ -396,14 +396,17 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f100c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100c(8-b)tx-pinctrl.dtsi
@@ -476,18 +476,22 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f100r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(4-6)hx-pinctrl.dtsi
@@ -432,14 +432,17 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f100r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(4-6)tx-pinctrl.dtsi
@@ -436,14 +436,17 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f100r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(8-b)hx-pinctrl.dtsi
@@ -512,22 +512,27 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f100r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(8-b)tx-pinctrl.dtsi
@@ -516,22 +516,27 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f100r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(c-d-e)tx-pinctrl.dtsi
@@ -598,30 +598,37 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f100v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100v(8-b)tx-pinctrl.dtsi
@@ -580,30 +580,37 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f100v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100v(c-d-e)tx-pinctrl.dtsi
@@ -662,38 +662,47 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f100z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100z(c-d-e)tx-pinctrl.dtsi
@@ -662,38 +662,47 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f101c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(4-6)tx-pinctrl.dtsi
@@ -286,14 +286,17 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f101c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(8-b)tx-pinctrl.dtsi
@@ -366,18 +366,22 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f101c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(8-b)ux-pinctrl.dtsi
@@ -366,18 +366,22 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f101r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(4-6)tx-pinctrl.dtsi
@@ -326,14 +326,17 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f101r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(8-b)tx-pinctrl.dtsi
@@ -406,22 +406,27 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f101r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(c-d-e)tx-pinctrl.dtsi
@@ -466,30 +466,37 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f101r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(f-g)tx-pinctrl.dtsi
@@ -498,30 +498,37 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f101rbhx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101rbhx-pinctrl.dtsi
@@ -402,22 +402,27 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f101t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101t(4-6)ux-pinctrl.dtsi
@@ -260,14 +260,17 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f101t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101t(8-b)ux-pinctrl.dtsi
@@ -268,14 +268,17 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f101v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(8-b)tx-pinctrl.dtsi
@@ -442,30 +442,37 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f101v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(c-d-e)tx-pinctrl.dtsi
@@ -502,38 +502,47 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f101v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(f-g)tx-pinctrl.dtsi
@@ -542,38 +542,47 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f101z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101z(c-d-e)tx-pinctrl.dtsi
@@ -502,38 +502,47 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f101z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101z(f-g)tx-pinctrl.dtsi
@@ -558,38 +558,47 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
@@ -286,14 +286,17 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
@@ -366,18 +366,22 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
@@ -326,14 +326,17 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
@@ -406,22 +406,27 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
@@ -402,14 +402,17 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
@@ -482,18 +482,22 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
@@ -402,14 +402,17 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103cbux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103cbux-pinctrl.dtsi
@@ -482,18 +482,22 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
@@ -458,14 +458,17 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
@@ -466,14 +466,17 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
@@ -538,22 +538,27 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
@@ -546,22 +546,27 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
@@ -696,30 +696,37 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
@@ -684,30 +684,37 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
@@ -728,30 +728,37 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
@@ -356,14 +356,17 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
@@ -364,14 +364,17 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
@@ -618,30 +618,37 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
@@ -618,30 +618,37 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
@@ -768,38 +768,47 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
@@ -768,38 +768,47 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
@@ -808,38 +808,47 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103vbix-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103vbix-pinctrl.dtsi
@@ -618,30 +618,37 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
@@ -788,38 +788,47 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
@@ -788,38 +788,47 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
@@ -844,38 +844,47 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
@@ -844,38 +844,47 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
@@ -698,30 +698,37 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
@@ -770,38 +770,47 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
@@ -770,38 +770,47 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
@@ -816,30 +816,37 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
@@ -912,38 +912,47 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f1/stm32f107vchx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107vchx-pinctrl.dtsi
@@ -912,38 +912,47 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32F1_PINMUX('D', 2, GPIO_IN, NO_REMAP)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX */

--- a/dts/st/f2/stm32f205r(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205r(b-c-e-f-g)tx-pinctrl.dtsi
@@ -684,19 +684,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -704,85 +701,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f2/stm32f205r(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205r(e-g)yx-pinctrl.dtsi
@@ -684,19 +684,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -704,85 +701,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f2/stm32f205rgex-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205rgex-pinctrl.dtsi
@@ -684,19 +684,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -704,85 +701,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
@@ -757,31 +757,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -789,103 +784,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
@@ -829,43 +829,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -873,112 +866,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
@@ -1132,43 +1132,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1176,112 +1169,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
@@ -1132,43 +1132,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1176,112 +1169,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
@@ -902,31 +902,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -934,103 +929,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
@@ -994,43 +994,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1038,112 +1031,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f2/stm32f215r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215r(e-g)tx-pinctrl.dtsi
@@ -684,19 +684,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -704,85 +701,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
@@ -757,31 +757,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -789,103 +784,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
@@ -829,43 +829,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -873,112 +866,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
@@ -1132,43 +1132,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1176,112 +1169,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
@@ -1132,43 +1132,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1176,112 +1169,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
@@ -902,31 +902,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -934,103 +929,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
@@ -994,43 +994,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1038,112 +1031,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f3/stm32f301c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301c(6-8)tx-pinctrl.dtsi
@@ -456,19 +456,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -476,67 +473,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f301c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301c8yx-pinctrl.dtsi
@@ -456,19 +456,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -476,67 +473,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f301k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301k(6-8)tx-pinctrl.dtsi
@@ -347,13 +347,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -361,49 +359,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f301k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301k(6-8)ux-pinctrl.dtsi
@@ -339,13 +339,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -353,49 +351,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f301r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301r(6-8)tx-pinctrl.dtsi
@@ -518,19 +518,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -538,85 +535,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f302c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c(6-8)tx-pinctrl.dtsi
@@ -478,19 +478,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -498,67 +495,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f302c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c(b-c)tx-pinctrl.dtsi
@@ -525,19 +525,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -545,58 +542,58 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f302c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c8yx-pinctrl.dtsi
@@ -478,19 +478,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -498,67 +495,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f302k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302k(6-8)ux-pinctrl.dtsi
@@ -352,13 +352,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -366,49 +364,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f302r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(6-8)tx-pinctrl.dtsi
@@ -540,19 +540,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -560,85 +557,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f302r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(b-c)tx-pinctrl.dtsi
@@ -609,19 +609,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -629,94 +626,94 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f302r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(d-e)tx-pinctrl.dtsi
@@ -680,19 +680,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -700,103 +697,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f302v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(b-c)tx-pinctrl.dtsi
@@ -755,37 +755,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -793,125 +787,126 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
@@ -1071,37 +1071,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1109,134 +1103,135 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
@@ -1071,37 +1071,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1109,134 +1103,135 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f302vcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302vcyx-pinctrl.dtsi
@@ -731,37 +731,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -769,107 +763,108 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
@@ -1195,37 +1195,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1233,134 +1227,135 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f303c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c(6-8)tx-pinctrl.dtsi
@@ -424,19 +424,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -444,67 +441,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f303c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c(b-c)tx-pinctrl.dtsi
@@ -597,19 +597,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -617,58 +614,58 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f303c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c8yx-pinctrl.dtsi
@@ -444,19 +444,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -464,76 +461,76 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f303k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303k(6-8)tx-pinctrl.dtsi
@@ -327,13 +327,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -341,49 +339,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f303k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303k(6-8)ux-pinctrl.dtsi
@@ -315,13 +315,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -329,49 +327,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f303r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(6-8)tx-pinctrl.dtsi
@@ -496,19 +496,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -516,85 +513,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f303r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(b-c)tx-pinctrl.dtsi
@@ -709,19 +709,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -729,94 +726,94 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f303r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(d-e)tx-pinctrl.dtsi
@@ -780,19 +780,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -800,103 +797,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f303v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(b-c)tx-pinctrl.dtsi
@@ -947,37 +947,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -985,125 +979,126 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
@@ -1291,37 +1291,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1329,134 +1323,135 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
@@ -1291,37 +1291,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1329,134 +1323,135 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f303vcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303vcyx-pinctrl.dtsi
@@ -899,37 +899,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -937,107 +931,108 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f303veyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303veyx-pinctrl.dtsi
@@ -1037,37 +1037,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1075,116 +1069,117 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
@@ -1463,37 +1463,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1501,134 +1495,135 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f318c8tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318c8tx-pinctrl.dtsi
@@ -456,19 +456,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -476,67 +473,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f318c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318c8yx-pinctrl.dtsi
@@ -456,19 +456,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -476,67 +473,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f318k8ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318k8ux-pinctrl.dtsi
@@ -329,13 +329,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -343,45 +341,44 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f328c8tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f328c8tx-pinctrl.dtsi
@@ -420,19 +420,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -440,67 +437,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f334c(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334c(4-6-8)tx-pinctrl.dtsi
@@ -424,19 +424,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -444,67 +441,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f334c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334c8yx-pinctrl.dtsi
@@ -444,19 +444,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -464,76 +461,76 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f334k(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334k(4-6-8)tx-pinctrl.dtsi
@@ -327,13 +327,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -341,49 +339,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f334k(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334k(4-6-8)ux-pinctrl.dtsi
@@ -315,13 +315,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -329,49 +327,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f334r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334r(6-8)tx-pinctrl.dtsi
@@ -496,19 +496,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -516,85 +513,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f358cctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358cctx-pinctrl.dtsi
@@ -593,19 +593,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -613,58 +610,58 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f358rctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358rctx-pinctrl.dtsi
@@ -705,19 +705,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -725,94 +722,94 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f358vctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358vctx-pinctrl.dtsi
@@ -943,37 +943,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -981,125 +975,126 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f373c(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373c(8-b-c)tx-pinctrl.dtsi
@@ -725,25 +725,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -751,54 +747,53 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f373r(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373r(8-b-c)tx-pinctrl.dtsi
@@ -893,25 +893,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -919,72 +915,71 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f373v(8-b-c)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373v(8-b-c)hx-pinctrl.dtsi
@@ -979,37 +979,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1017,103 +1011,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f373v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373v(8-b-c)tx-pinctrl.dtsi
@@ -979,37 +979,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1017,103 +1011,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/f3/stm32f378cctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378cctx-pinctrl.dtsi
@@ -725,25 +725,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -751,54 +747,53 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f378rctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378rctx-pinctrl.dtsi
@@ -893,25 +893,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -919,72 +915,71 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f378rcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378rcyx-pinctrl.dtsi
@@ -893,25 +893,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -919,72 +915,71 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f378vchx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378vchx-pinctrl.dtsi
@@ -979,37 +979,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1017,103 +1011,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f378vctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378vctx-pinctrl.dtsi
@@ -979,37 +979,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1017,103 +1011,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f3/stm32f398vetx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f398vetx-pinctrl.dtsi
@@ -1287,37 +1287,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1325,134 +1319,135 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f401c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(b-c)ux-pinctrl.dtsi
@@ -416,13 +416,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -430,40 +428,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f401c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(b-c)yx-pinctrl.dtsi
@@ -416,13 +416,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -430,40 +428,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f401c(d-e)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(d-e)ux-pinctrl.dtsi
@@ -416,13 +416,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -430,40 +428,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f401c(d-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(d-e)yx-pinctrl.dtsi
@@ -416,13 +416,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -430,40 +428,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f401ccfx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401ccfx-pinctrl.dtsi
@@ -416,13 +416,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -430,40 +428,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f401r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401r(b-c)tx-pinctrl.dtsi
@@ -500,13 +500,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -514,49 +512,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f401r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401r(d-e)tx-pinctrl.dtsi
@@ -500,13 +500,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -514,49 +512,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f401v(b-c)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(b-c)hx-pinctrl.dtsi
@@ -627,19 +627,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -647,58 +644,58 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f401v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(b-c)tx-pinctrl.dtsi
@@ -617,19 +617,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -637,58 +634,58 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f401v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(d-e)hx-pinctrl.dtsi
@@ -627,19 +627,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -647,58 +644,58 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f401v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(d-e)tx-pinctrl.dtsi
@@ -617,19 +617,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -637,58 +634,58 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f405o(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405o(e-g)yx-pinctrl.dtsi
@@ -756,31 +756,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -788,103 +783,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f405rgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405rgtx-pinctrl.dtsi
@@ -706,19 +706,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -726,85 +723,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
@@ -779,31 +779,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -811,103 +806,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
@@ -851,43 +851,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -895,112 +888,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
@@ -1159,43 +1159,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1203,112 +1196,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
@@ -1159,43 +1159,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1203,112 +1196,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
@@ -924,31 +924,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -956,103 +951,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
@@ -1016,43 +1016,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1060,112 +1053,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f410c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410c(8-b)tx-pinctrl.dtsi
@@ -345,13 +345,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -359,49 +357,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f410c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410c(8-b)ux-pinctrl.dtsi
@@ -370,13 +370,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -384,49 +382,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f410r(8-b)ix-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410r(8-b)ix-pinctrl.dtsi
@@ -448,13 +448,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -462,58 +460,58 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f410r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410r(8-b)tx-pinctrl.dtsi
@@ -448,13 +448,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -462,58 +460,58 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f410t(8-b)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410t(8-b)yx-pinctrl.dtsi
@@ -167,7 +167,6 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -175,31 +174,31 @@
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/f4/stm32f411c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411c(c-e)ux-pinctrl.dtsi
@@ -539,13 +539,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -553,49 +551,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f411c(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411c(c-e)yx-pinctrl.dtsi
@@ -539,13 +539,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -553,49 +551,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f411r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411r(c-e)tx-pinctrl.dtsi
@@ -633,13 +633,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -647,58 +645,58 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f411v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411v(c-e)hx-pinctrl.dtsi
@@ -852,19 +852,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -872,67 +869,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f411v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411v(c-e)tx-pinctrl.dtsi
@@ -842,19 +842,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -862,67 +859,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f412c(e-g)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412c(e-g)ux-pinctrl.dtsi
@@ -619,13 +619,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -633,54 +631,53 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f412r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)tx-pinctrl.dtsi
@@ -797,19 +797,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -817,76 +814,76 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f412r(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)yx-pinctrl.dtsi
@@ -797,19 +797,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -817,76 +814,76 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f412r(e-g)yxp-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)yxp-pinctrl.dtsi
@@ -797,19 +797,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -817,76 +814,76 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f412v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412v(e-g)hx-pinctrl.dtsi
@@ -1076,31 +1076,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1108,93 +1103,95 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f412v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412v(e-g)tx-pinctrl.dtsi
@@ -1066,31 +1066,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1098,94 +1093,94 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f412z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412z(e-g)jx-pinctrl.dtsi
@@ -1185,43 +1185,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1229,107 +1222,108 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f412z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412z(e-g)tx-pinctrl.dtsi
@@ -1185,43 +1185,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1229,107 +1222,108 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f413c(g-h)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413c(g-h)ux-pinctrl.dtsi
@@ -680,13 +680,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -694,112 +692,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF11)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f413m(g-h)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413m(g-h)yx-pinctrl.dtsi
@@ -963,19 +963,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -983,165 +980,167 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd10: uart4_tx_pd10 {
 				pinmux = <STM32_PINMUX('D', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f413r(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413r(g-h)tx-pinctrl.dtsi
@@ -858,19 +858,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -878,152 +875,153 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
@@ -1137,31 +1137,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1169,219 +1164,221 @@
 
 			uart10_rx_pe2: uart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			uart10_tx_pe3: uart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd10: uart4_tx_pd10 {
 				pinmux = <STM32_PINMUX('D', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
@@ -1127,31 +1127,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1159,220 +1154,220 @@
 
 			uart10_rx_pe2: uart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			uart10_tx_pe3: uart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd10: uart4_tx_pd10 {
 				pinmux = <STM32_PINMUX('D', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
@@ -1246,43 +1246,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1290,269 +1283,270 @@
 
 			uart10_rx_pe2: uart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			uart10_rx_pg11: uart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pf8: uart8_rx_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			uart10_tx_pe3: uart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			uart10_tx_pg12: uart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd10: uart4_tx_pd10 {
 				pinmux = <STM32_PINMUX('D', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pf9: uart8_tx_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
@@ -1246,43 +1246,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1290,269 +1283,270 @@
 
 			uart10_rx_pe2: uart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			uart10_rx_pg11: uart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pf8: uart8_rx_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			uart10_tx_pe3: uart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			uart10_tx_pg12: uart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd10: uart4_tx_pd10 {
 				pinmux = <STM32_PINMUX('D', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pf9: uart8_tx_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f415ogyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415ogyx-pinctrl.dtsi
@@ -756,31 +756,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -788,103 +783,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f415rgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415rgtx-pinctrl.dtsi
@@ -706,19 +706,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -726,85 +723,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
@@ -779,31 +779,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -811,103 +806,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
@@ -851,43 +851,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -895,112 +888,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
@@ -1159,43 +1159,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1203,112 +1196,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
@@ -1159,43 +1159,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1203,112 +1196,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
@@ -924,31 +924,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -956,103 +951,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
@@ -1016,43 +1016,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1060,112 +1053,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f423chux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423chux-pinctrl.dtsi
@@ -680,13 +680,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -694,112 +692,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF11)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f423mhyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423mhyx-pinctrl.dtsi
@@ -963,19 +963,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -983,165 +980,167 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd10: uart4_tx_pd10 {
 				pinmux = <STM32_PINMUX('D', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f423rhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423rhtx-pinctrl.dtsi
@@ -858,19 +858,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -878,152 +875,153 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
@@ -1137,31 +1137,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1169,219 +1164,221 @@
 
 			uart10_rx_pe2: uart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			uart10_tx_pe3: uart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd10: uart4_tx_pd10 {
 				pinmux = <STM32_PINMUX('D', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
@@ -1127,31 +1127,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1159,220 +1154,220 @@
 
 			uart10_rx_pe2: uart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			uart10_tx_pe3: uart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd10: uart4_tx_pd10 {
 				pinmux = <STM32_PINMUX('D', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
@@ -1246,43 +1246,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1290,269 +1283,270 @@
 
 			uart10_rx_pe2: uart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			uart10_rx_pg11: uart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pf8: uart8_rx_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			uart10_tx_pe3: uart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			uart10_tx_pg12: uart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd10: uart4_tx_pd10 {
 				pinmux = <STM32_PINMUX('D', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pf9: uart8_tx_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
@@ -1246,43 +1246,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1290,269 +1283,270 @@
 
 			uart10_rx_pe2: uart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			uart10_rx_pg11: uart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb3: usart1_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa12: usart6_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pf8: uart8_rx_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			uart10_tx_pe3: uart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			uart10_tx_pg12: uart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa15: usart1_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd10: uart4_tx_pd10 {
 				pinmux = <STM32_PINMUX('D', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF11)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa11: usart6_tx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pf9: uart8_tx_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
@@ -1672,43 +1672,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1716,121 +1709,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
@@ -1784,43 +1784,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1828,139 +1821,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
@@ -1784,43 +1784,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1828,139 +1821,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
@@ -1207,31 +1207,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1239,121 +1234,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
@@ -1488,43 +1488,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1532,139 +1525,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
@@ -1672,43 +1672,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1716,121 +1709,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
@@ -1784,43 +1784,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1828,139 +1821,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
@@ -1784,43 +1784,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1828,139 +1821,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
@@ -1784,43 +1784,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1828,139 +1821,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f429iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429iitx-pinctrl.dtsi
@@ -1784,43 +1784,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1828,139 +1821,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
@@ -1784,43 +1784,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1828,139 +1821,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f429nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429nihx-pinctrl.dtsi
@@ -1784,43 +1784,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1828,139 +1821,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
@@ -1177,31 +1177,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1209,121 +1204,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f429vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429vitx-pinctrl.dtsi
@@ -1177,31 +1177,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1209,121 +1204,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
@@ -1488,43 +1488,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1532,139 +1525,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
@@ -1488,43 +1488,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1532,139 +1525,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f429zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zitx-pinctrl.dtsi
@@ -1488,43 +1488,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1532,139 +1525,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
@@ -1488,43 +1488,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1532,139 +1525,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f437aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437aihx-pinctrl.dtsi
@@ -1672,43 +1672,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1716,121 +1709,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
@@ -1784,43 +1784,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1828,139 +1821,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
@@ -1784,43 +1784,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1828,139 +1821,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
@@ -1207,31 +1207,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1239,121 +1234,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
@@ -1488,43 +1488,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1532,139 +1525,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f439aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439aihx-pinctrl.dtsi
@@ -1672,43 +1672,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1716,121 +1709,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
@@ -1784,43 +1784,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1828,139 +1821,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
@@ -1784,43 +1784,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1828,139 +1821,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
@@ -1784,43 +1784,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1828,139 +1821,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
@@ -1784,43 +1784,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1828,139 +1821,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
@@ -1177,31 +1177,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1209,121 +1204,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
@@ -1488,43 +1488,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1532,139 +1525,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
@@ -1488,43 +1488,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1532,139 +1525,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
@@ -940,43 +940,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -984,94 +977,94 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pe7: uart5_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pe8: uart5_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
@@ -861,31 +861,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -893,85 +888,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
@@ -1303,43 +1303,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1347,112 +1340,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pe7: uart5_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pe8: uart5_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
@@ -1584,55 +1584,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1640,125 +1631,126 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pe7: uart5_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pe8: uart5_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
@@ -1584,55 +1584,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1640,125 +1631,126 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pe7: uart5_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pe8: uart5_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
@@ -1584,55 +1584,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1640,125 +1631,126 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pe7: uart5_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pe8: uart5_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
@@ -1551,43 +1551,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1595,125 +1588,126 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
@@ -1551,43 +1551,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1595,125 +1588,126 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
@@ -1949,43 +1949,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1993,139 +1986,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
@@ -1848,43 +1848,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1892,139 +1885,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
@@ -1848,43 +1848,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1892,139 +1885,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f469iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469iitx-pinctrl.dtsi
@@ -1848,43 +1848,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1892,139 +1885,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
@@ -1949,43 +1949,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1993,139 +1986,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f469nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469nihx-pinctrl.dtsi
@@ -1949,43 +1949,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1993,139 +1986,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
@@ -1036,25 +1036,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1062,112 +1058,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f469vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469vitx-pinctrl.dtsi
@@ -1036,25 +1036,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1062,112 +1058,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
@@ -1337,43 +1337,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1381,125 +1374,126 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f469zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469zitx-pinctrl.dtsi
@@ -1337,43 +1337,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1381,125 +1374,126 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
@@ -1551,43 +1551,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1595,125 +1588,126 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
@@ -1551,43 +1551,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1595,125 +1588,126 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
@@ -1949,43 +1949,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1993,139 +1986,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
@@ -1848,43 +1848,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1892,139 +1885,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
@@ -1848,43 +1848,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1892,139 +1885,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
@@ -1949,43 +1949,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1993,139 +1986,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
@@ -1036,25 +1036,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1062,112 +1058,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
@@ -1337,43 +1337,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1381,125 +1374,126 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
@@ -1924,73 +1924,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1998,152 +1986,153 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
@@ -1924,73 +1924,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1998,152 +1986,153 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
@@ -839,31 +839,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -871,85 +866,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
@@ -1323,55 +1323,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1379,121 +1370,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
@@ -1638,73 +1638,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1712,139 +1700,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
@@ -1870,67 +1870,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1938,152 +1927,153 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
@@ -1870,67 +1870,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1938,152 +1927,153 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f723v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)tx-pinctrl.dtsi
@@ -1217,49 +1217,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1267,112 +1259,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
@@ -1217,49 +1217,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1267,112 +1259,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
@@ -1584,67 +1584,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1652,139 +1641,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
@@ -1584,67 +1584,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1652,139 +1641,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
@@ -1870,67 +1870,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1938,152 +1927,153 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
@@ -839,31 +839,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -871,85 +866,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
@@ -1323,55 +1323,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1379,121 +1370,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
@@ -1584,67 +1584,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1652,139 +1641,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f732iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732iekx-pinctrl.dtsi
@@ -1924,73 +1924,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1998,152 +1986,153 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f732ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732ietx-pinctrl.dtsi
@@ -1924,73 +1924,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1998,152 +1986,153 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f732retx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732retx-pinctrl.dtsi
@@ -839,31 +839,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -871,85 +866,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f732vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732vetx-pinctrl.dtsi
@@ -1323,55 +1323,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1379,121 +1370,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f732zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732zetx-pinctrl.dtsi
@@ -1638,73 +1638,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1712,139 +1700,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f733iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733iekx-pinctrl.dtsi
@@ -1870,67 +1870,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1938,152 +1927,153 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f733ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733ietx-pinctrl.dtsi
@@ -1870,67 +1870,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1938,152 +1927,153 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f733vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733vetx-pinctrl.dtsi
@@ -1217,49 +1217,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1267,112 +1259,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f733veyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733veyx-pinctrl.dtsi
@@ -1217,49 +1217,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1267,112 +1259,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f733zeix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zeix-pinctrl.dtsi
@@ -1584,67 +1584,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1652,139 +1641,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f733zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zetx-pinctrl.dtsi
@@ -1584,67 +1584,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1652,139 +1641,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
@@ -2107,73 +2107,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2181,139 +2169,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
@@ -2107,73 +2107,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2181,139 +2169,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
@@ -1448,55 +1448,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1504,121 +1495,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
@@ -1448,55 +1448,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1504,121 +1495,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
@@ -1789,73 +1789,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1863,139 +1851,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
@@ -2107,73 +2107,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2181,139 +2169,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
@@ -2107,73 +2107,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2181,139 +2169,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f746ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746ietx-pinctrl.dtsi
@@ -2107,73 +2107,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2181,139 +2169,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f746igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746igtx-pinctrl.dtsi
@@ -2107,73 +2107,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2181,139 +2169,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f746nehx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nehx-pinctrl.dtsi
@@ -2107,73 +2107,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2181,139 +2169,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f746nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nghx-pinctrl.dtsi
@@ -2107,73 +2107,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2181,139 +2169,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
@@ -1448,55 +1448,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1504,121 +1495,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f746vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vetx-pinctrl.dtsi
@@ -1448,55 +1448,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1504,121 +1495,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
@@ -1448,55 +1448,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1504,121 +1495,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
@@ -1789,73 +1789,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1863,139 +1851,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f746zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zetx-pinctrl.dtsi
@@ -1789,73 +1789,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1863,139 +1851,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
@@ -1789,73 +1789,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1863,139 +1851,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
@@ -2107,73 +2107,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2181,139 +2169,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
@@ -1448,55 +1448,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1504,121 +1495,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
@@ -1789,73 +1789,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1863,139 +1851,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
@@ -2107,73 +2107,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2181,139 +2169,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f756igkx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igkx-pinctrl.dtsi
@@ -2107,73 +2107,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2181,139 +2169,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f756igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igtx-pinctrl.dtsi
@@ -2107,73 +2107,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2181,139 +2169,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f756nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756nghx-pinctrl.dtsi
@@ -2107,73 +2107,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2181,139 +2169,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f756vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vghx-pinctrl.dtsi
@@ -1448,55 +1448,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1504,121 +1495,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
@@ -1448,55 +1448,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1504,121 +1495,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
@@ -1789,73 +1789,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1863,139 +1851,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
@@ -1789,73 +1789,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1863,139 +1851,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
@@ -2362,79 +2362,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2442,224 +2429,225 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
@@ -2362,79 +2362,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2442,224 +2429,225 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
@@ -2362,79 +2362,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2442,224 +2429,225 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
@@ -2362,79 +2362,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2442,224 +2429,225 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
@@ -1643,61 +1643,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1705,193 +1695,193 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
@@ -1643,61 +1643,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1705,193 +1695,193 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
@@ -2039,79 +2039,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2119,211 +2106,211 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
@@ -2362,79 +2362,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2442,224 +2429,225 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
@@ -2362,79 +2362,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2442,224 +2429,225 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
@@ -2362,79 +2362,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2442,224 +2429,225 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
@@ -2362,79 +2362,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2442,224 +2429,225 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f767vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vghx-pinctrl.dtsi
@@ -1643,61 +1643,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1705,193 +1695,193 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
@@ -1643,61 +1643,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1705,193 +1695,193 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f767vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vihx-pinctrl.dtsi
@@ -1643,61 +1643,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1705,193 +1695,193 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f767vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vitx-pinctrl.dtsi
@@ -1643,61 +1643,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1705,193 +1695,193 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
@@ -2039,79 +2039,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2119,211 +2106,211 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f767zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zitx-pinctrl.dtsi
@@ -2039,79 +2039,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2119,211 +2106,211 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
@@ -1958,73 +1958,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2032,210 +2020,212 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
@@ -1958,73 +1958,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2032,210 +2020,212 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
@@ -2362,79 +2362,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2442,224 +2429,225 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f769igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769igtx-pinctrl.dtsi
@@ -2244,79 +2244,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2324,215 +2311,216 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f769iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769iitx-pinctrl.dtsi
@@ -2244,79 +2244,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2324,215 +2311,216 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f769nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nghx-pinctrl.dtsi
@@ -2362,79 +2362,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2442,224 +2429,225 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f769nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nihx-pinctrl.dtsi
@@ -2362,79 +2362,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2442,224 +2429,225 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f777bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777bitx-pinctrl.dtsi
@@ -2362,79 +2362,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2442,224 +2429,225 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f777iikx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iikx-pinctrl.dtsi
@@ -2362,79 +2362,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2442,224 +2429,225 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f777iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iitx-pinctrl.dtsi
@@ -2362,79 +2362,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2442,224 +2429,225 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f777nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777nihx-pinctrl.dtsi
@@ -2362,79 +2362,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2442,224 +2429,225 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f777vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vihx-pinctrl.dtsi
@@ -1643,61 +1643,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1705,193 +1695,193 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f777vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vitx-pinctrl.dtsi
@@ -1643,61 +1643,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1705,193 +1695,193 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f777zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777zitx-pinctrl.dtsi
@@ -2039,79 +2039,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2119,211 +2106,211 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
@@ -1958,73 +1958,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2032,210 +2020,212 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
@@ -1958,73 +1958,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2032,210 +2020,212 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f779bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779bitx-pinctrl.dtsi
@@ -2362,79 +2362,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2442,224 +2429,225 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f779iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779iitx-pinctrl.dtsi
@@ -2244,79 +2244,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2324,215 +2311,216 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/f7/stm32f779nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779nihx-pinctrl.dtsi
@@ -2362,79 +2362,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2442,224 +2429,225 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb8: uart5_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF1)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb9: uart5_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF12)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/g0/stm32g030c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030c(6-8)tx-pinctrl.dtsi
@@ -572,19 +572,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -592,49 +589,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g030f6px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030f6px-pinctrl.dtsi
@@ -427,19 +427,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -447,40 +444,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g030j6mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030j6mx-pinctrl.dtsi
@@ -292,7 +292,6 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -300,22 +299,22 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g030k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030k(6-8)tx-pinctrl.dtsi
@@ -461,19 +461,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -481,49 +478,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g031c(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031c(4-6-8)tx-pinctrl.dtsi
@@ -628,31 +628,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -660,67 +655,67 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g031c(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031c(4-6-8)ux-pinctrl.dtsi
@@ -632,31 +632,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -664,67 +659,67 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g031f(4-6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031f(4-6-8)px-pinctrl.dtsi
@@ -461,25 +461,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -487,49 +483,49 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g031g(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031g(4-6-8)ux-pinctrl.dtsi
@@ -445,25 +445,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -471,49 +467,49 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g031j(4-6)mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031j(4-6)mx-pinctrl.dtsi
@@ -308,13 +308,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -322,27 +320,26 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g031k(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031k(4-6-8)tx-pinctrl.dtsi
@@ -499,25 +499,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -525,58 +521,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g031k(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031k(4-6-8)ux-pinctrl.dtsi
@@ -499,25 +499,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -525,58 +521,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g031y8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031y8yx-pinctrl.dtsi
@@ -461,25 +461,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -487,49 +483,49 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g041c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041c(6-8)tx-pinctrl.dtsi
@@ -628,31 +628,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -660,67 +655,67 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g041c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041c(6-8)ux-pinctrl.dtsi
@@ -632,31 +632,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -664,67 +659,67 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g041f(6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041f(6-8)px-pinctrl.dtsi
@@ -461,25 +461,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -487,49 +483,49 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g041g(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041g(6-8)ux-pinctrl.dtsi
@@ -445,25 +445,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -471,49 +467,49 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g041j6mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041j6mx-pinctrl.dtsi
@@ -308,13 +308,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -322,27 +320,26 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g041k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041k(6-8)tx-pinctrl.dtsi
@@ -499,25 +499,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -525,58 +521,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g041k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041k(6-8)ux-pinctrl.dtsi
@@ -499,25 +499,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -525,58 +521,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g041y8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041y8yx-pinctrl.dtsi
@@ -461,25 +461,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -487,49 +483,49 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g070cbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070cbtx-pinctrl.dtsi
@@ -614,49 +614,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -664,90 +656,89 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g070kbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070kbtx-pinctrl.dtsi
@@ -465,37 +465,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -503,81 +497,80 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g070rbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070rbtx-pinctrl.dtsi
@@ -710,55 +710,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -766,144 +757,143 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g071c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071c(6-8-b)tx-pinctrl.dtsi
@@ -680,61 +680,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -742,108 +732,107 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g071c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071c(6-8-b)ux-pinctrl.dtsi
@@ -680,61 +680,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -742,108 +732,107 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g071ebyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071ebyx-pinctrl.dtsi
@@ -418,37 +418,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -456,72 +450,71 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g071g(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071g(6-8-b)ux-pinctrl.dtsi
@@ -459,43 +459,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -503,72 +496,71 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g071g(8-b)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071g(8-b)uxn-pinctrl.dtsi
@@ -438,19 +438,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -458,68 +455,66 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g071k(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(6-8-b)tx-pinctrl.dtsi
@@ -513,43 +513,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -557,90 +550,89 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g071k(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(6-8-b)ux-pinctrl.dtsi
@@ -513,43 +513,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -557,90 +550,89 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g071k(8-b)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(8-b)txn-pinctrl.dtsi
@@ -499,31 +499,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -531,81 +526,80 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g071k(8-b)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(8-b)uxn-pinctrl.dtsi
@@ -499,31 +499,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -531,81 +526,80 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi
@@ -784,67 +784,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -852,171 +841,170 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g071rbix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071rbix-pinctrl.dtsi
@@ -784,67 +784,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -852,171 +841,170 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g081cbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081cbtx-pinctrl.dtsi
@@ -680,61 +680,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -742,108 +732,107 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g081cbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081cbux-pinctrl.dtsi
@@ -680,61 +680,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -742,108 +732,107 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g081ebyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081ebyx-pinctrl.dtsi
@@ -418,37 +418,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -456,72 +450,71 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g081gbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081gbux-pinctrl.dtsi
@@ -459,43 +459,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -503,72 +496,71 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g081gbuxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081gbuxn-pinctrl.dtsi
@@ -438,19 +438,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -458,68 +455,66 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g081kbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbtx-pinctrl.dtsi
@@ -513,43 +513,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -557,90 +550,89 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g081kbtxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbtxn-pinctrl.dtsi
@@ -499,31 +499,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -531,81 +526,80 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g081kbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbux-pinctrl.dtsi
@@ -513,43 +513,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -557,90 +550,89 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g081kbuxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbuxn-pinctrl.dtsi
@@ -499,31 +499,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -531,81 +526,80 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g081rbix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081rbix-pinctrl.dtsi
@@ -784,67 +784,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -852,171 +841,170 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g081rbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081rbtx-pinctrl.dtsi
@@ -784,67 +784,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -852,171 +841,170 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/g0/stm32g0b0cetx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0cetx-pinctrl.dtsi
@@ -810,67 +810,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pb14: usart6_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -878,135 +867,134 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0b0ketx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0ketx-pinctrl.dtsi
@@ -624,49 +624,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -674,117 +666,116 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0b0retx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0retx-pinctrl.dtsi
@@ -947,79 +947,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pd4: usart5_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pb14: usart6_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1027,203 +1014,201 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0b0vetx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0vetx-pinctrl.dtsi
@@ -1074,103 +1074,86 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pd4: usart5_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pb14: usart6_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pf3: usart6_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pf11: usart6_rts_pf11 {
 				pinmux = <STM32_PINMUX('F', 11, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1178,230 +1161,228 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pf10: usart6_rx_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pf9: usart6_tx_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0b1c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(c-e)tx-pinctrl.dtsi
@@ -934,91 +934,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pb14: usart6_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1026,185 +1011,183 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc7: lpuart2_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc6: lpuart2_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0b1c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(c-e)ux-pinctrl.dtsi
@@ -934,91 +934,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pb14: usart6_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1026,185 +1011,183 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc7: lpuart2_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc6: lpuart2_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0b1k(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(c-e)tx-pinctrl.dtsi
@@ -714,67 +714,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -782,154 +771,151 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc6: lpuart2_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0b1k(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(c-e)txn-pinctrl.dtsi
@@ -666,49 +666,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -716,140 +708,138 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0b1k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(c-e)ux-pinctrl.dtsi
@@ -714,67 +714,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -782,154 +771,151 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc6: lpuart2_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0b1k(c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(c-e)uxn-pinctrl.dtsi
@@ -666,49 +666,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -716,140 +708,138 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0b1m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1m(c-e)tx-pinctrl.dtsi
@@ -1169,127 +1169,106 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pc9: lpuart2_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pd15: lpuart2_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pd4: usart5_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pb14: usart6_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1297,285 +1276,281 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc1: lpuart2_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc7: lpuart2_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc0: lpuart2_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF3)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc6: lpuart2_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0b1r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(c-e)ix-pinctrl.dtsi
@@ -1101,109 +1101,91 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pc9: lpuart2_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pd4: usart5_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pb14: usart6_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1211,271 +1193,268 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc1: lpuart2_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc7: lpuart2_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc0: lpuart2_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF3)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc6: lpuart2_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0b1r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(c-e)tx-pinctrl.dtsi
@@ -1101,109 +1101,91 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pc9: lpuart2_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pd4: usart5_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pb14: usart6_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1211,271 +1193,268 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc1: lpuart2_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc7: lpuart2_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc0: lpuart2_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF3)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc6: lpuart2_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0b1v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1v(c-e)ix-pinctrl.dtsi
@@ -1256,145 +1256,121 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pf6: lpuart1_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pc9: lpuart2_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pd15: lpuart2_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pd4: usart5_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pb14: usart6_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pf3: usart6_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pf11: usart6_rts_pf11 {
 				pinmux = <STM32_PINMUX('F', 11, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1402,311 +1378,309 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pf5: lpuart1_rx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc1: lpuart2_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc7: lpuart2_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pf3: lpuart2_rx_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pf10: usart6_rx_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pf4: lpuart1_tx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc0: lpuart2_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF3)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc6: lpuart2_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pf9: usart6_tx_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0b1v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1v(c-e)tx-pinctrl.dtsi
@@ -1256,145 +1256,121 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pf6: lpuart1_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pc9: lpuart2_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pd15: lpuart2_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pd4: usart5_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pb14: usart6_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pf3: usart6_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pf11: usart6_rts_pf11 {
 				pinmux = <STM32_PINMUX('F', 11, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1402,311 +1378,309 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pf5: lpuart1_rx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc1: lpuart2_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc7: lpuart2_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pf3: lpuart2_rx_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pf10: usart6_rx_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pf4: lpuart1_tx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc0: lpuart2_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF3)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc6: lpuart2_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pf9: usart6_tx_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0c1c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)tx-pinctrl.dtsi
@@ -934,91 +934,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pb14: usart6_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1026,185 +1011,183 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc7: lpuart2_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc6: lpuart2_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0c1c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)ux-pinctrl.dtsi
@@ -934,91 +934,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pb14: usart6_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1026,185 +1011,183 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc7: lpuart2_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc6: lpuart2_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0c1k(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)tx-pinctrl.dtsi
@@ -714,67 +714,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -782,154 +771,151 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc6: lpuart2_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0c1k(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)txn-pinctrl.dtsi
@@ -666,49 +666,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -716,140 +708,138 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0c1k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)ux-pinctrl.dtsi
@@ -714,67 +714,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -782,154 +771,151 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc6: lpuart2_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0c1k(c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)uxn-pinctrl.dtsi
@@ -666,49 +666,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -716,140 +708,138 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0c1m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1m(c-e)tx-pinctrl.dtsi
@@ -1169,127 +1169,106 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pc9: lpuart2_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pd15: lpuart2_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pd4: usart5_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pb14: usart6_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1297,285 +1276,281 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc1: lpuart2_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc7: lpuart2_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc0: lpuart2_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF3)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc6: lpuart2_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0c1r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)ix-pinctrl.dtsi
@@ -1101,109 +1101,91 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pc9: lpuart2_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pd4: usart5_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pb14: usart6_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1211,271 +1193,268 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc1: lpuart2_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc7: lpuart2_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc0: lpuart2_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF3)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc6: lpuart2_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0c1r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)tx-pinctrl.dtsi
@@ -1101,109 +1101,91 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pc9: lpuart2_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pd4: usart5_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pb14: usart6_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1211,271 +1193,268 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc1: lpuart2_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc7: lpuart2_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc0: lpuart2_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF3)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc6: lpuart2_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0c1v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1v(c-e)ix-pinctrl.dtsi
@@ -1256,145 +1256,121 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pf6: lpuart1_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pc9: lpuart2_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pd15: lpuart2_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pd4: usart5_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pb14: usart6_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pf3: usart6_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pf11: usart6_rts_pf11 {
 				pinmux = <STM32_PINMUX('F', 11, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1402,311 +1378,309 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pf5: lpuart1_rx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc1: lpuart2_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc7: lpuart2_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pf3: lpuart2_rx_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pf10: usart6_rx_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pf4: lpuart1_tx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc0: lpuart2_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF3)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc6: lpuart2_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pf9: usart6_tx_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g0/stm32g0c1v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1v(c-e)tx-pinctrl.dtsi
@@ -1256,145 +1256,121 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pf6: lpuart1_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pb1: lpuart2_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pc9: lpuart2_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pd15: lpuart2_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF1)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart2_rts_pf2: lpuart2_rts_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pd4: usart5_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pa7: usart6_rts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pb14: usart6_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pf3: usart6_rts_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pf11: usart6_rts_pf11 {
 				pinmux = <STM32_PINMUX('F', 11, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1402,311 +1378,309 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF1)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pf5: lpuart1_rx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF1)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pa13: lpuart2_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF10)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pb7: lpuart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF10)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc1: lpuart2_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF3)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pc7: lpuart2_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart2_rx_pf3: lpuart2_rx_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, AF1)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb0: usart3_rx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb9: usart3_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF1)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb1: usart5_rx_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF3)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pa5: usart6_rx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF3)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pb9: usart6_rx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc1: usart6_rx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF4)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pf10: usart6_rx_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF1)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pf4: lpuart1_tx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF1)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pa14: lpuart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF10)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF1)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pb6: lpuart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF10)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc0: lpuart2_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF3)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pc6: lpuart2_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF3)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart2_tx_pf2: lpuart2_tx_pf2 {
 				pinmux = <STM32_PINMUX('F', 2, AF1)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pa5: usart3_tx_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb2: usart3_tx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb8: usart3_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF1)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb0: usart5_tx_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pd3: usart5_tx_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pa4: usart6_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF3)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pb8: usart6_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc0: usart6_tx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF4)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pf9: usart6_tx_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g431c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431c(6-8-b)tx-pinctrl.dtsi
@@ -674,31 +674,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -706,85 +701,85 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g431c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431c(6-8-b)ux-pinctrl.dtsi
@@ -721,31 +721,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -753,99 +748,98 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g431cbyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431cbyx-pinctrl.dtsi
@@ -707,31 +707,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -739,94 +734,94 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g431k(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431k(6-8-b)tx-pinctrl.dtsi
@@ -517,13 +517,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -531,58 +529,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g431k(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431k(6-8-b)ux-pinctrl.dtsi
@@ -517,13 +517,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -531,58 +529,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g431m(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431m(6-8-b)tx-pinctrl.dtsi
@@ -880,37 +880,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -918,134 +912,135 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g431r(6-8-b)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431r(6-8-b)ix-pinctrl.dtsi
@@ -832,37 +832,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -870,121 +864,121 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi
@@ -832,37 +832,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -870,121 +864,121 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
@@ -971,49 +971,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1021,152 +1013,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g441cbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbtx-pinctrl.dtsi
@@ -674,31 +674,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -706,85 +701,85 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g441cbux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbux-pinctrl.dtsi
@@ -721,31 +721,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -753,99 +748,98 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g441cbyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbyx-pinctrl.dtsi
@@ -707,31 +707,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -739,94 +734,94 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g441kbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441kbtx-pinctrl.dtsi
@@ -517,13 +517,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -531,58 +529,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g441kbux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441kbux-pinctrl.dtsi
@@ -517,13 +517,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -531,58 +529,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g441mbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441mbtx-pinctrl.dtsi
@@ -880,37 +880,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -918,134 +912,135 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g441rbix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441rbix-pinctrl.dtsi
@@ -832,37 +832,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -870,121 +864,121 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g441rbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441rbtx-pinctrl.dtsi
@@ -832,37 +832,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -870,121 +864,121 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
@@ -971,49 +971,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1021,152 +1013,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
@@ -734,31 +734,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -766,85 +761,85 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
@@ -787,31 +787,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -819,99 +814,98 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
@@ -1022,43 +1022,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1066,143 +1059,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g471meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471meyx-pinctrl.dtsi
@@ -1032,43 +1032,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1076,143 +1069,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
@@ -1263,67 +1263,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1331,175 +1320,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
@@ -914,43 +914,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -958,130 +951,130 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
@@ -1158,55 +1158,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1214,161 +1205,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
@@ -1158,55 +1158,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1214,161 +1205,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
@@ -1158,55 +1158,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1214,161 +1205,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
@@ -778,31 +778,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -810,85 +805,85 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
@@ -831,31 +831,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -863,99 +858,98 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
@@ -1138,43 +1138,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1182,143 +1175,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g473meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473meyx-pinctrl.dtsi
@@ -1156,43 +1156,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1200,143 +1193,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g473p(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473p(b-c-e)ix-pinctrl.dtsi
@@ -1763,61 +1763,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1825,161 +1815,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
@@ -1831,67 +1831,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1899,175 +1888,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
@@ -966,43 +966,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1010,130 +1003,130 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
@@ -1556,55 +1556,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1612,161 +1603,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g473v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)ix-pinctrl.dtsi
@@ -1556,55 +1556,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1612,161 +1603,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
@@ -1556,55 +1556,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1612,161 +1603,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
@@ -778,31 +778,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -810,85 +805,85 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
@@ -831,31 +831,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -863,99 +858,98 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
@@ -1138,43 +1138,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1182,143 +1175,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g474meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474meyx-pinctrl.dtsi
@@ -1156,43 +1156,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1200,143 +1193,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g474p(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474p(b-c-e)ix-pinctrl.dtsi
@@ -1763,61 +1763,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1825,161 +1815,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
@@ -1831,67 +1831,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1899,175 +1888,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
@@ -966,43 +966,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1010,130 +1003,130 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
@@ -1556,55 +1556,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1612,161 +1603,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g474v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)ix-pinctrl.dtsi
@@ -1556,55 +1556,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1612,161 +1603,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
@@ -1556,55 +1556,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1612,161 +1603,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g483cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483cetx-pinctrl.dtsi
@@ -778,31 +778,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -810,85 +805,85 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g483ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483ceux-pinctrl.dtsi
@@ -831,31 +831,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -863,99 +858,98 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g483metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483metx-pinctrl.dtsi
@@ -1138,43 +1138,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1182,143 +1175,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g483meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483meyx-pinctrl.dtsi
@@ -1156,43 +1156,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1200,143 +1193,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g483peix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483peix-pinctrl.dtsi
@@ -1763,61 +1763,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1825,161 +1815,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g483qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483qetx-pinctrl.dtsi
@@ -1831,67 +1831,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1899,175 +1888,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g483retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483retx-pinctrl.dtsi
@@ -966,43 +966,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1010,130 +1003,130 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g483vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vehx-pinctrl.dtsi
@@ -1556,55 +1556,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1612,161 +1603,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g483veix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483veix-pinctrl.dtsi
@@ -1556,55 +1556,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1612,161 +1603,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g483vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vetx-pinctrl.dtsi
@@ -1556,55 +1556,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1612,161 +1603,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g484cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484cetx-pinctrl.dtsi
@@ -778,31 +778,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -810,85 +805,85 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g484ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484ceux-pinctrl.dtsi
@@ -831,31 +831,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -863,99 +858,98 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g484metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484metx-pinctrl.dtsi
@@ -1138,43 +1138,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1182,143 +1175,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g484meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484meyx-pinctrl.dtsi
@@ -1156,43 +1156,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1200,143 +1193,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g484peix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484peix-pinctrl.dtsi
@@ -1763,61 +1763,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1825,161 +1815,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g484qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484qetx-pinctrl.dtsi
@@ -1831,67 +1831,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pf6: usart3_rts_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1899,175 +1888,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g484retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484retx-pinctrl.dtsi
@@ -966,43 +966,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1010,130 +1003,130 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g484vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vehx-pinctrl.dtsi
@@ -1556,55 +1556,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1612,161 +1603,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g484veix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484veix-pinctrl.dtsi
@@ -1556,55 +1556,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1612,161 +1603,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g484vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vetx-pinctrl.dtsi
@@ -1556,55 +1556,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1612,161 +1603,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g491c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491c(c-e)tx-pinctrl.dtsi
@@ -706,31 +706,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -738,85 +733,85 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g491c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491c(c-e)ux-pinctrl.dtsi
@@ -753,31 +753,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -785,99 +780,98 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g491k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491k(c-e)ux-pinctrl.dtsi
@@ -529,13 +529,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -543,58 +541,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g491m(c-e)sx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491m(c-e)sx-pinctrl.dtsi
@@ -958,43 +958,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1002,143 +995,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g491m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491m(c-e)tx-pinctrl.dtsi
@@ -958,43 +958,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1002,143 +995,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g491r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491r(c-e)ix-pinctrl.dtsi
@@ -878,43 +878,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -922,130 +915,130 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g491r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491r(c-e)tx-pinctrl.dtsi
@@ -878,43 +878,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -922,130 +915,130 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g491reyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491reyx-pinctrl.dtsi
@@ -878,43 +878,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -922,130 +915,130 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g491v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491v(c-e)tx-pinctrl.dtsi
@@ -1097,55 +1097,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1153,161 +1144,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g4a1cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1cetx-pinctrl.dtsi
@@ -706,31 +706,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -738,85 +733,85 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g4a1ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1ceux-pinctrl.dtsi
@@ -753,31 +753,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -785,99 +780,98 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g4a1keux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1keux-pinctrl.dtsi
@@ -529,13 +529,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -543,58 +541,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g4a1mesx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1mesx-pinctrl.dtsi
@@ -958,43 +958,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1002,143 +995,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g4a1metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1metx-pinctrl.dtsi
@@ -958,43 +958,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1002,143 +995,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g4a1reix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1reix-pinctrl.dtsi
@@ -878,43 +878,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -922,130 +915,130 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g4a1retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1retx-pinctrl.dtsi
@@ -878,43 +878,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -922,130 +915,130 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g4a1reyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1reyx-pinctrl.dtsi
@@ -878,43 +878,36 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -922,130 +915,130 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32g4a1vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1vetx-pinctrl.dtsi
@@ -1097,55 +1097,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1153,161 +1144,162 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pe1: usart1_rx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pe15: usart3_rx_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF5)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pc4: usart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pe0: usart1_tx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF5)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/g4/stm32gbk1cbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32gbk1cbtx-pinctrl.dtsi
@@ -738,31 +738,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF12)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -770,98 +765,99 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pc5: usart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb4: usart2_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb8: usart3_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF12)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb3: usart2_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb9: usart3_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/h7/stm32h723vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vehx-pinctrl.dtsi
@@ -1720,73 +1720,61 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1794,229 +1782,229 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h723vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vetx-pinctrl.dtsi
@@ -1720,73 +1720,61 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1794,229 +1782,229 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h723vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vghx-pinctrl.dtsi
@@ -1720,73 +1720,61 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1794,229 +1782,229 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
@@ -1720,73 +1720,61 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1794,229 +1782,229 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h723zeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zeix-pinctrl.dtsi
@@ -2275,97 +2275,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2373,265 +2357,265 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h723zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zetx-pinctrl.dtsi
@@ -2247,97 +2247,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2345,265 +2329,265 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h723zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgix-pinctrl.dtsi
@@ -2275,97 +2275,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2373,265 +2357,265 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
@@ -2247,97 +2247,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2345,265 +2329,265 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h725aeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725aeix-pinctrl.dtsi
@@ -2502,97 +2502,81 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2600,265 +2584,265 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h725agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725agix-pinctrl.dtsi
@@ -2502,97 +2502,81 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2600,265 +2584,265 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h725iekx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725iekx-pinctrl.dtsi
@@ -2621,103 +2621,86 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2725,283 +2708,283 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h725ietx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725ietx-pinctrl.dtsi
@@ -2315,97 +2315,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2413,274 +2397,274 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h725igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igkx-pinctrl.dtsi
@@ -2621,103 +2621,86 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2725,283 +2708,283 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h725igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igtx-pinctrl.dtsi
@@ -2315,97 +2315,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2413,274 +2397,274 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h725revx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725revx-pinctrl.dtsi
@@ -1109,37 +1109,31 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1147,153 +1141,152 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
@@ -1109,37 +1109,31 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1147,153 +1141,152 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h725vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vehx-pinctrl.dtsi
@@ -1648,67 +1648,56 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1716,211 +1705,211 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h725vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vetx-pinctrl.dtsi
@@ -1557,61 +1557,51 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1619,198 +1609,197 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h725vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vghx-pinctrl.dtsi
@@ -1648,67 +1648,56 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1716,211 +1705,211 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
@@ -1557,61 +1557,51 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1619,198 +1609,197 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
@@ -1496,67 +1496,56 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1564,211 +1553,211 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h725zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zetx-pinctrl.dtsi
@@ -2075,97 +2075,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2173,256 +2157,256 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
@@ -2075,97 +2075,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2173,256 +2157,256 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h730abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730abixq-pinctrl.dtsi
@@ -2409,91 +2409,76 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2501,256 +2486,256 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
@@ -2528,97 +2528,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2626,274 +2610,274 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
@@ -2279,97 +2279,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2377,274 +2361,274 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
@@ -1684,73 +1684,61 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1758,229 +1746,229 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
@@ -1684,73 +1684,61 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1758,229 +1746,229 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h730zbix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbix-pinctrl.dtsi
@@ -2275,97 +2275,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2373,265 +2357,265 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
@@ -2211,97 +2211,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2309,265 +2293,265 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h733vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vghx-pinctrl.dtsi
@@ -1720,73 +1720,61 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1794,229 +1782,229 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
@@ -1720,73 +1720,61 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1794,229 +1782,229 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h733zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgix-pinctrl.dtsi
@@ -2275,97 +2275,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2373,265 +2357,265 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
@@ -2247,97 +2247,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2345,265 +2329,265 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h735agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735agix-pinctrl.dtsi
@@ -2502,97 +2502,81 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2600,265 +2584,265 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h735igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igkx-pinctrl.dtsi
@@ -2621,103 +2621,86 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2725,283 +2708,283 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h735igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igtx-pinctrl.dtsi
@@ -2315,97 +2315,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2413,274 +2397,274 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
@@ -1109,37 +1109,31 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1147,153 +1141,152 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h735vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vghx-pinctrl.dtsi
@@ -1648,67 +1648,56 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1716,211 +1705,211 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
@@ -1557,61 +1557,51 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1619,198 +1609,197 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
@@ -1496,67 +1496,56 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1564,211 +1553,211 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
@@ -2075,97 +2075,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2173,256 +2157,256 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -2287,85 +2287,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2373,229 +2359,229 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -2502,85 +2502,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2588,251 +2574,252 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -2390,85 +2390,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2476,242 +2462,243 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -2390,85 +2390,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2476,242 +2462,243 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -1642,67 +1642,56 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1710,211 +1699,211 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -1642,67 +1642,56 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1710,211 +1699,211 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -2566,85 +2566,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2652,251 +2638,252 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -2081,85 +2081,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2167,229 +2153,229 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -2287,85 +2287,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2373,229 +2359,229 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -2502,85 +2502,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2588,251 +2574,252 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -2502,85 +2502,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2588,251 +2574,252 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -2426,85 +2426,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2512,242 +2498,243 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -2426,85 +2426,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2512,242 +2498,243 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -2426,85 +2426,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2512,242 +2498,243 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -2426,85 +2426,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2512,242 +2498,243 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -1642,67 +1642,56 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1710,211 +1699,211 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -1642,67 +1642,56 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1710,211 +1699,211 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -1642,67 +1642,56 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1710,211 +1699,211 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -2566,85 +2566,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2652,251 +2638,252 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -2566,85 +2566,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2652,251 +2638,252 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -2081,85 +2081,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2167,229 +2153,229 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -2081,85 +2081,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2167,229 +2153,229 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -2502,85 +2502,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2588,251 +2574,252 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -2502,85 +2502,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2588,251 +2574,252 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -2372,85 +2372,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2458,238 +2444,238 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -2149,85 +2149,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2235,238 +2221,238 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -2372,85 +2372,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2458,238 +2444,238 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -2149,85 +2149,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2235,238 +2221,238 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -2566,85 +2566,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2652,251 +2638,252 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -2566,85 +2566,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2652,251 +2638,252 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -1945,85 +1945,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2031,229 +2017,229 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -1945,85 +1945,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2031,229 +2017,229 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -2081,85 +2081,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2167,229 +2153,229 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -2426,85 +2426,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2512,242 +2498,243 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -2426,85 +2426,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2512,242 +2498,243 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -2081,85 +2081,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2167,229 +2153,229 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -2081,85 +2081,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2167,229 +2153,229 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -2566,85 +2566,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2652,251 +2638,252 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -2566,85 +2566,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2652,251 +2638,252 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -1836,73 +1836,61 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1910,211 +1898,211 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -2426,85 +2426,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2512,242 +2498,243 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -2390,85 +2390,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2476,242 +2462,243 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -1642,67 +1642,56 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1710,211 +1699,211 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -2566,85 +2566,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2652,251 +2638,252 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -2081,85 +2081,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2167,229 +2153,229 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -2287,85 +2287,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2373,229 +2359,229 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -2502,85 +2502,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2588,251 +2574,252 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -2426,85 +2426,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2512,242 +2498,243 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -2426,85 +2426,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2512,242 +2498,243 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -1642,67 +1642,56 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1710,211 +1699,211 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -1642,67 +1642,56 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1710,211 +1699,211 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -2566,85 +2566,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2652,251 +2638,252 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -2081,85 +2081,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2167,229 +2153,229 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -2502,85 +2502,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2588,251 +2574,252 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -2372,85 +2372,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2458,238 +2444,238 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -2149,85 +2149,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2235,238 +2221,238 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -2566,85 +2566,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2652,251 +2638,252 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -1945,85 +1945,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2031,229 +2017,229 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -2081,85 +2081,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2167,229 +2153,229 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -2426,85 +2426,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2512,242 +2498,243 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -2081,85 +2081,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2167,229 +2153,229 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -2566,85 +2566,71 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2652,251 +2638,252 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -1836,73 +1836,61 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1910,211 +1898,211 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -1948,97 +1948,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2046,274 +2030,274 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -2082,97 +2082,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2180,278 +2164,279 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -2035,97 +2035,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2133,274 +2117,274 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -2082,97 +2082,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2180,278 +2164,279 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -1868,97 +1868,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1966,274 +1950,274 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -2230,103 +2230,86 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pj3: uart9_rts_pj3 {
 				pinmux = <STM32_PINMUX('J', 3, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2334,287 +2317,288 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -2164,103 +2164,86 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pj3: uart9_rts_pj3 {
 				pinmux = <STM32_PINMUX('J', 3, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2268,287 +2251,288 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
@@ -1576,79 +1576,66 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1656,243 +1643,242 @@
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
@@ -993,37 +993,31 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1031,162 +1025,161 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
@@ -1434,73 +1434,61 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1508,229 +1496,229 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
@@ -1368,73 +1368,61 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1442,229 +1430,229 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
@@ -1434,73 +1434,61 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1508,229 +1496,229 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
@@ -1283,67 +1283,56 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1351,211 +1340,211 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -1800,97 +1800,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1898,265 +1882,265 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
@@ -1680,97 +1680,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1778,256 +1762,256 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -1948,97 +1948,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2046,274 +2030,274 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -2035,97 +2035,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2133,274 +2117,274 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -2082,97 +2082,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2180,278 +2164,279 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
@@ -993,37 +993,31 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1031,162 +1025,161 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
@@ -1434,73 +1434,61 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1508,229 +1496,229 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -1800,97 +1800,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1898,265 +1882,265 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -1948,97 +1948,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2046,274 +2030,274 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -2082,97 +2082,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2180,278 +2164,279 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -2035,97 +2035,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2133,274 +2117,274 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -2082,97 +2082,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2180,278 +2164,279 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -1868,97 +1868,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1966,274 +1950,274 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -2230,103 +2230,86 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pj3: uart9_rts_pj3 {
 				pinmux = <STM32_PINMUX('J', 3, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2334,287 +2317,288 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -2164,103 +2164,86 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pj3: uart9_rts_pj3 {
 				pinmux = <STM32_PINMUX('J', 3, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2268,287 +2251,288 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
@@ -1576,79 +1576,66 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1656,243 +1643,242 @@
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
@@ -993,37 +993,31 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1031,162 +1025,161 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
@@ -1434,73 +1434,61 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1508,229 +1496,229 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
@@ -1368,73 +1368,61 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1442,229 +1430,229 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
@@ -1434,73 +1434,61 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1508,229 +1496,229 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
@@ -1283,67 +1283,56 @@
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1351,211 +1340,211 @@
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -1800,97 +1800,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1898,265 +1882,265 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pg0: uart9_rx_pg0 {
 				pinmux = <STM32_PINMUX('G', 0, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pg1: uart9_tx_pg1 {
 				pinmux = <STM32_PINMUX('G', 1, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
@@ -1680,97 +1680,81 @@
 
 			usart10_rts_pg14: usart10_rts_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF3)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pb14: uart4_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart9_rts_pd13: uart9_rts_pd13 {
 				pinmux = <STM32_PINMUX('D', 13, AF11)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1778,256 +1762,256 @@
 
 			usart10_rx_pe2: usart10_rx_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				bias-pull-up;
 			};
 
 			usart10_rx_pg11: usart10_rx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF11)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart9_rx_pd14: uart9_rx_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart10_tx_pe3: usart10_tx_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF11)>;
-				bias-pull-up;
 			};
 
 			usart10_tx_pg12: usart10_tx_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF11)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart9_tx_pd15: uart9_tx_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF11)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/l0/stm32l010c6tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010c6tx-pinctrl.dtsi
@@ -290,31 +290,26 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa12: usart2_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -322,71 +317,72 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l010f4px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010f4px-pinctrl.dtsi
@@ -189,13 +189,11 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -203,63 +201,62 @@
 
 			lpuart1_rx_pa0: lpuart1_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa0: usart2_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa1: lpuart1_tx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa4: lpuart1_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l010k4tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010k4tx-pinctrl.dtsi
@@ -282,25 +282,21 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa12: usart2_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -308,85 +304,85 @@
 
 			lpuart1_rx_pa0: lpuart1_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa0: usart2_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa1: lpuart1_tx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa4: lpuart1_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l010k8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010k8tx-pinctrl.dtsi
@@ -176,7 +176,6 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -184,22 +183,22 @@
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l010r8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010r8tx-pinctrl.dtsi
@@ -240,31 +240,26 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -272,49 +267,49 @@
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l010rbtx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010rbtx-pinctrl.dtsi
@@ -276,31 +276,26 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -308,85 +303,85 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l011d(3-4)px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011d(3-4)px-pinctrl.dtsi
@@ -124,7 +124,6 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -132,45 +131,44 @@
 
 			lpuart1_rx_pa0: lpuart1_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa0: usart2_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa1: lpuart1_tx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa4: lpuart1_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l011e(3-4)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011e(3-4)yx-pinctrl.dtsi
@@ -239,19 +239,16 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -259,81 +256,80 @@
 
 			lpuart1_rx_pa0: lpuart1_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa0: usart2_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa1: lpuart1_tx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa4: lpuart1_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l011f(3-4)px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011f(3-4)px-pinctrl.dtsi
@@ -189,13 +189,11 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -203,63 +201,62 @@
 
 			lpuart1_rx_pa0: lpuart1_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa0: usart2_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa1: lpuart1_tx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa4: lpuart1_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l011f(3-4)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011f(3-4)ux-pinctrl.dtsi
@@ -185,13 +185,11 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -199,63 +197,62 @@
 
 			lpuart1_rx_pa0: lpuart1_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa0: usart2_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa1: lpuart1_tx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa4: lpuart1_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l011g(3-4)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011g(3-4)ux-pinctrl.dtsi
@@ -262,19 +262,16 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -282,85 +279,85 @@
 
 			lpuart1_rx_pa0: lpuart1_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa0: usart2_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa1: lpuart1_tx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa4: lpuart1_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l011k(3-4)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011k(3-4)tx-pinctrl.dtsi
@@ -282,25 +282,21 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa12: usart2_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -308,85 +304,85 @@
 
 			lpuart1_rx_pa0: lpuart1_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa0: usart2_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa1: lpuart1_tx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa4: lpuart1_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l011k(3-4)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011k(3-4)ux-pinctrl.dtsi
@@ -293,25 +293,21 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa12: usart2_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -319,90 +315,89 @@
 
 			lpuart1_rx_pa0: lpuart1_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa0: usart2_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa1: lpuart1_tx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa4: lpuart1_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb8: usart2_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l021d4px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021d4px-pinctrl.dtsi
@@ -124,7 +124,6 @@
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -132,45 +131,44 @@
 
 			lpuart1_rx_pa0: lpuart1_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa0: usart2_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa1: lpuart1_tx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa4: lpuart1_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l021f4px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021f4px-pinctrl.dtsi
@@ -189,13 +189,11 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -203,63 +201,62 @@
 
 			lpuart1_rx_pa0: lpuart1_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa0: usart2_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa1: lpuart1_tx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa4: lpuart1_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l021f4ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021f4ux-pinctrl.dtsi
@@ -185,13 +185,11 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -199,63 +197,62 @@
 
 			lpuart1_rx_pa0: lpuart1_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa0: usart2_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa1: lpuart1_tx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa4: lpuart1_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l021g4ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021g4ux-pinctrl.dtsi
@@ -262,19 +262,16 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -282,85 +279,85 @@
 
 			lpuart1_rx_pa0: lpuart1_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa0: usart2_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa1: lpuart1_tx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa4: lpuart1_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l021k4tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021k4tx-pinctrl.dtsi
@@ -282,25 +282,21 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa12: usart2_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -308,85 +304,85 @@
 
 			lpuart1_rx_pa0: lpuart1_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa0: usart2_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa1: lpuart1_tx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa4: lpuart1_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l021k4ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021k4ux-pinctrl.dtsi
@@ -293,25 +293,21 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa12: usart2_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -319,90 +315,89 @@
 
 			lpuart1_rx_pa0: lpuart1_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb7: lpuart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa0: usart2_rx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa1: lpuart1_tx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa4: lpuart1_tx_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb6: lpuart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb8: usart2_tx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l031c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031c(4-6)tx-pinctrl.dtsi
@@ -314,31 +314,26 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa12: usart2_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -346,71 +341,72 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l031c(4-6)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031c(4-6)ux-pinctrl.dtsi
@@ -314,31 +314,26 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa12: usart2_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -346,71 +341,72 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l031e(4-6)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031e(4-6)yx-pinctrl.dtsi
@@ -213,19 +213,16 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -233,54 +230,53 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l031f(4-6)px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031f(4-6)px-pinctrl.dtsi
@@ -171,13 +171,11 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -185,45 +183,44 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l031g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031g(4-6)ux-pinctrl.dtsi
@@ -222,19 +222,16 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -242,58 +239,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l031g6uxs-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031g6uxs-pinctrl.dtsi
@@ -240,19 +240,16 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -260,58 +257,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l031k(4-6)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031k(4-6)tx-pinctrl.dtsi
@@ -260,25 +260,21 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa12: usart2_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -286,58 +282,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l031k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031k(4-6)ux-pinctrl.dtsi
@@ -266,25 +266,21 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa12: usart2_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -292,58 +288,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l041c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041c(4-6)tx-pinctrl.dtsi
@@ -314,31 +314,26 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa12: usart2_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -346,71 +341,72 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l041c6ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041c6ux-pinctrl.dtsi
@@ -314,31 +314,26 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa12: usart2_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -346,71 +341,72 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l041e6yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041e6yx-pinctrl.dtsi
@@ -213,19 +213,16 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -233,54 +230,53 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l041f6px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041f6px-pinctrl.dtsi
@@ -171,13 +171,11 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -185,45 +183,44 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l041g6ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041g6ux-pinctrl.dtsi
@@ -222,19 +222,16 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -242,58 +239,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l041g6uxs-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041g6uxs-pinctrl.dtsi
@@ -240,19 +240,16 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -260,58 +257,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l041k6tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041k6tx-pinctrl.dtsi
@@ -260,25 +260,21 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa12: usart2_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -286,58 +282,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l041k6ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041k6ux-pinctrl.dtsi
@@ -266,25 +266,21 @@
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa12: usart2_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pb0: usart2_rts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -292,58 +288,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa10: usart2_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pb7: usart2_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa9: usart2_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pb6: usart2_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l051c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051c(6-8)tx-pinctrl.dtsi
@@ -315,31 +315,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -347,49 +342,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l051c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051c(6-8)ux-pinctrl.dtsi
@@ -315,31 +315,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -347,49 +342,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l051k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051k(6-8)tx-pinctrl.dtsi
@@ -198,13 +198,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -212,40 +210,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l051k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051k(6-8)ux-pinctrl.dtsi
@@ -204,13 +204,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -218,40 +216,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l051r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051r(6-8)hx-pinctrl.dtsi
@@ -348,37 +348,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -386,67 +380,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l051r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051r(6-8)tx-pinctrl.dtsi
@@ -361,37 +361,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -399,67 +393,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l051t(6-8)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051t(6-8)yx-pinctrl.dtsi
@@ -230,19 +230,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -250,49 +247,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l052c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052c(6-8)tx-pinctrl.dtsi
@@ -321,31 +321,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -353,49 +348,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l052c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052c(6-8)ux-pinctrl.dtsi
@@ -321,31 +321,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -353,49 +348,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l052k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052k(6-8)tx-pinctrl.dtsi
@@ -204,13 +204,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -218,40 +216,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l052k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052k(6-8)ux-pinctrl.dtsi
@@ -210,13 +210,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -224,40 +222,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l052r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052r(6-8)hx-pinctrl.dtsi
@@ -354,37 +354,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -392,67 +386,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l052r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052r(6-8)tx-pinctrl.dtsi
@@ -367,37 +367,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -405,67 +399,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l052t(6-8)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052t(6-8)yx-pinctrl.dtsi
@@ -236,19 +236,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -256,49 +253,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l052t8fx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052t8fx-pinctrl.dtsi
@@ -236,19 +236,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -256,49 +253,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l053c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053c(6-8)tx-pinctrl.dtsi
@@ -321,31 +321,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -353,49 +348,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l053c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053c(6-8)ux-pinctrl.dtsi
@@ -321,31 +321,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -353,49 +348,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l053r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053r(6-8)hx-pinctrl.dtsi
@@ -354,37 +354,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -392,67 +386,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l053r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053r(6-8)tx-pinctrl.dtsi
@@ -367,37 +367,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -405,67 +399,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l062c8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l062c8ux-pinctrl.dtsi
@@ -321,31 +321,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -353,49 +348,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l062k8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l062k8tx-pinctrl.dtsi
@@ -204,13 +204,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -218,40 +216,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l062k8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l062k8ux-pinctrl.dtsi
@@ -210,13 +210,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -224,40 +222,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l063c8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063c8tx-pinctrl.dtsi
@@ -321,31 +321,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -353,49 +348,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l063c8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063c8ux-pinctrl.dtsi
@@ -321,31 +321,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -353,49 +348,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l063r8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063r8tx-pinctrl.dtsi
@@ -367,37 +367,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -405,67 +399,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l071c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c(b-z)tx-pinctrl.dtsi
@@ -375,49 +375,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -425,94 +417,94 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l071c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c(b-z)ux-pinctrl.dtsi
@@ -375,49 +375,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -425,94 +417,94 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l071c(b-z)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c(b-z)yx-pinctrl.dtsi
@@ -404,49 +404,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -454,103 +446,103 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l071c8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c8tx-pinctrl.dtsi
@@ -375,49 +375,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -425,94 +417,94 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l071c8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c8ux-pinctrl.dtsi
@@ -375,49 +375,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -425,94 +417,94 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l071k(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071k(b-z)tx-pinctrl.dtsi
@@ -264,37 +264,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -302,76 +296,76 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l071k(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071k(b-z)ux-pinctrl.dtsi
@@ -246,19 +246,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -266,63 +263,62 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l071k8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071k8ux-pinctrl.dtsi
@@ -246,19 +246,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -266,63 +263,62 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l071r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071r(b-z)hx-pinctrl.dtsi
@@ -442,55 +442,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -498,139 +489,139 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l071r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071r(b-z)tx-pinctrl.dtsi
@@ -455,55 +455,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -511,139 +502,139 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l071v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v(b-z)ix-pinctrl.dtsi
@@ -576,73 +576,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd12: lpuart1_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -650,175 +638,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pd9: lpuart1_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pd8: lpuart1_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF6)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l071v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v(b-z)tx-pinctrl.dtsi
@@ -576,73 +576,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd12: lpuart1_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -650,175 +638,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pd9: lpuart1_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pd8: lpuart1_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF6)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l071v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v8ix-pinctrl.dtsi
@@ -576,73 +576,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd12: lpuart1_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -650,175 +638,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pd9: lpuart1_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pd8: lpuart1_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF6)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l071v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v8tx-pinctrl.dtsi
@@ -576,73 +576,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd12: lpuart1_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -650,175 +638,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pd9: lpuart1_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pd8: lpuart1_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF6)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l072c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)tx-pinctrl.dtsi
@@ -385,49 +385,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -435,94 +427,94 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l072c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)ux-pinctrl.dtsi
@@ -385,49 +385,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -435,94 +427,94 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l072c(b-z)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)yx-pinctrl.dtsi
@@ -414,49 +414,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -464,103 +456,103 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l072czex-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072czex-pinctrl.dtsi
@@ -414,49 +414,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -464,103 +456,103 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l072k(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072k(b-z)tx-pinctrl.dtsi
@@ -274,37 +274,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -312,76 +306,76 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l072k(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072k(b-z)ux-pinctrl.dtsi
@@ -256,19 +256,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -276,63 +273,62 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l072r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)hx-pinctrl.dtsi
@@ -452,55 +452,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -508,139 +499,139 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l072r(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)ix-pinctrl.dtsi
@@ -452,55 +452,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -508,139 +499,139 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l072r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)tx-pinctrl.dtsi
@@ -465,55 +465,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -521,139 +512,139 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l072v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v(b-z)ix-pinctrl.dtsi
@@ -586,73 +586,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd12: lpuart1_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -660,175 +648,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pd9: lpuart1_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pd8: lpuart1_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l072v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v(b-z)tx-pinctrl.dtsi
@@ -586,73 +586,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd12: lpuart1_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -660,175 +648,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pd9: lpuart1_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pd8: lpuart1_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l072v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v8ix-pinctrl.dtsi
@@ -586,73 +586,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd12: lpuart1_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -660,175 +648,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pd9: lpuart1_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pd8: lpuart1_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l072v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v8tx-pinctrl.dtsi
@@ -586,73 +586,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd12: lpuart1_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -660,175 +648,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pd9: lpuart1_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pd8: lpuart1_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l073c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073c(b-z)tx-pinctrl.dtsi
@@ -385,49 +385,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -435,94 +427,94 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l073c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073c(b-z)ux-pinctrl.dtsi
@@ -385,49 +385,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -435,94 +427,94 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l073czyx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073czyx-pinctrl.dtsi
@@ -414,49 +414,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -464,103 +456,103 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l073r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073r(b-z)hx-pinctrl.dtsi
@@ -452,55 +452,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -508,139 +499,139 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l073r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073r(b-z)tx-pinctrl.dtsi
@@ -465,55 +465,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -521,139 +512,139 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l073rzix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073rzix-pinctrl.dtsi
@@ -452,55 +452,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -508,139 +499,139 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l073v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v(b-z)ix-pinctrl.dtsi
@@ -586,73 +586,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd12: lpuart1_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -660,175 +648,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pd9: lpuart1_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pd8: lpuart1_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l073v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v(b-z)tx-pinctrl.dtsi
@@ -586,73 +586,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd12: lpuart1_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -660,175 +648,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pd9: lpuart1_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pd8: lpuart1_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l073v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v8ix-pinctrl.dtsi
@@ -586,73 +586,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd12: lpuart1_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -660,175 +648,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pd9: lpuart1_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pd8: lpuart1_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l073v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v8tx-pinctrl.dtsi
@@ -586,73 +586,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd12: lpuart1_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -660,175 +648,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pd9: lpuart1_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pd8: lpuart1_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l081c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081c(b-z)tx-pinctrl.dtsi
@@ -375,49 +375,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -425,94 +417,94 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l081czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081czux-pinctrl.dtsi
@@ -375,49 +375,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -425,94 +417,94 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l081kztx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081kztx-pinctrl.dtsi
@@ -264,37 +264,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -302,76 +296,76 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l081kzux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081kzux-pinctrl.dtsi
@@ -246,19 +246,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -266,63 +263,62 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l0/stm32l082czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082czux-pinctrl.dtsi
@@ -385,49 +385,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -435,94 +427,94 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l082czyx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082czyx-pinctrl.dtsi
@@ -414,49 +414,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -464,103 +456,103 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l082k(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082k(b-z)tx-pinctrl.dtsi
@@ -274,37 +274,31 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -312,76 +306,76 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l082k(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082k(b-z)ux-pinctrl.dtsi
@@ -256,19 +256,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -276,63 +273,62 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l083c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083c(b-z)tx-pinctrl.dtsi
@@ -385,49 +385,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -435,94 +427,94 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l083czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083czux-pinctrl.dtsi
@@ -385,49 +385,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -435,94 +427,94 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l083r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083r(b-z)hx-pinctrl.dtsi
@@ -452,55 +452,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -508,139 +499,139 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l083r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083r(b-z)tx-pinctrl.dtsi
@@ -465,55 +465,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -521,139 +512,139 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l083v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v(b-z)ix-pinctrl.dtsi
@@ -586,73 +586,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd12: lpuart1_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -660,175 +648,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pd9: lpuart1_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pd8: lpuart1_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l083v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v(b-z)tx-pinctrl.dtsi
@@ -586,73 +586,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd12: lpuart1_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -660,175 +648,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pd9: lpuart1_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pd8: lpuart1_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l083v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v8ix-pinctrl.dtsi
@@ -586,73 +586,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd12: lpuart1_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -660,175 +648,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pd9: lpuart1_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pd8: lpuart1_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l0/stm32l083v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v8tx-pinctrl.dtsi
@@ -586,73 +586,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF2)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb14: lpuart1_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd2: lpuart1_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pd12: lpuart1_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF0)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart4_rts_pa15: usart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pb5: usart5_rts_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart5_rts_pe7: usart5_rts_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF6)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -660,175 +648,175 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa13: lpuart1_rx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb11: lpuart1_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF4)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF6)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc5: lpuart1_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF2)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc11: lpuart1_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF0)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pd9: lpuart1_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF0)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF0)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pa1: usart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pc11: usart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			usart4_rx_pe9: usart4_rx_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pb4: usart5_rx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pd2: usart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			usart5_rx_pe11: usart5_rx_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pa14: lpuart1_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF6)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb10: lpuart1_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF4)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF6)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc4: lpuart1_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF2)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc10: lpuart1_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF0)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pd8: lpuart1_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF0)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa14: usart2_tx_pa14 {
 				pinmux = <STM32_PINMUX('A', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF0)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pa0: usart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pc10: usart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			usart4_tx_pe8: usart4_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pb3: usart5_tx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pc12: usart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF2)>;
-				bias-pull-up;
 			};
 
 			usart5_tx_pe10: usart5_tx_pe10 {
 				pinmux = <STM32_PINMUX('E', 10, AF6)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l100c6ux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100c6ux-pinctrl.dtsi
@@ -338,19 +338,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -358,40 +355,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l100c6uxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100c6uxa-pinctrl.dtsi
@@ -338,19 +338,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -358,40 +355,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l100r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100r(8-b)tx-pinctrl.dtsi
@@ -378,19 +378,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -398,49 +395,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l100r(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100r(8-b)txa-pinctrl.dtsi
@@ -378,19 +378,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -398,49 +395,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l100rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100rctx-pinctrl.dtsi
@@ -463,19 +463,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -483,49 +480,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)tx-pinctrl.dtsi
@@ -338,19 +338,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -358,40 +355,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151c(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)txa-pinctrl.dtsi
@@ -338,19 +338,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -358,40 +355,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)ux-pinctrl.dtsi
@@ -338,19 +338,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -358,40 +355,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151c(6-8-b)uxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)uxa-pinctrl.dtsi
@@ -338,19 +338,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -358,40 +355,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151cctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151cctx-pinctrl.dtsi
@@ -415,19 +415,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -435,40 +432,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151ccux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151ccux-pinctrl.dtsi
@@ -415,19 +415,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -435,40 +432,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qchx-pinctrl.dtsi
@@ -656,31 +656,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -688,67 +683,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qdhx-pinctrl.dtsi
@@ -656,31 +656,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -688,85 +683,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151qehx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qehx-pinctrl.dtsi
@@ -656,31 +656,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -688,85 +683,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151r(6-8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)hx-pinctrl.dtsi
@@ -374,19 +374,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -394,49 +391,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151r(6-8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)hxa-pinctrl.dtsi
@@ -374,19 +374,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -394,49 +391,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)tx-pinctrl.dtsi
@@ -378,19 +378,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -398,49 +395,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151r(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)txa-pinctrl.dtsi
@@ -378,19 +378,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -398,49 +395,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rctx-pinctrl.dtsi
@@ -479,19 +479,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -499,49 +496,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rctxa-pinctrl.dtsi
@@ -479,19 +479,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -499,49 +496,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151rcyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rcyx-pinctrl.dtsi
@@ -479,19 +479,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -499,49 +496,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rdtx-pinctrl.dtsi
@@ -479,19 +479,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -499,67 +496,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rdyx-pinctrl.dtsi
@@ -479,19 +479,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -499,67 +496,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151retx-pinctrl.dtsi
@@ -479,19 +479,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -499,67 +496,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151ucyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151ucyx-pinctrl.dtsi
@@ -479,19 +479,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -499,49 +496,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)hx-pinctrl.dtsi
@@ -510,31 +510,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -542,67 +537,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151v(8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)hxa-pinctrl.dtsi
@@ -510,31 +510,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -542,67 +537,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)tx-pinctrl.dtsi
@@ -510,31 +510,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -542,67 +537,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151v(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)txa-pinctrl.dtsi
@@ -510,31 +510,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -542,67 +537,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vchx-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,67 +651,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vctx-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,67 +651,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vctxa-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,67 +651,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdtx-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,85 +651,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151vdtxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdtxx-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,85 +651,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151vdyxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdyxx-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,85 +651,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vetx-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,85 +651,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151veyx-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,85 +651,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zctx-pinctrl.dtsi
@@ -660,31 +660,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -692,67 +687,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zdtx-pinctrl.dtsi
@@ -660,31 +660,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -692,85 +687,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l151zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zetx-pinctrl.dtsi
@@ -660,31 +660,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -692,85 +687,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)tx-pinctrl.dtsi
@@ -338,19 +338,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -358,40 +355,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152c(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)txa-pinctrl.dtsi
@@ -338,19 +338,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -358,40 +355,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)ux-pinctrl.dtsi
@@ -338,19 +338,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -358,40 +355,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152c(6-8-b)uxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)uxa-pinctrl.dtsi
@@ -338,19 +338,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -358,40 +355,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152cctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152cctx-pinctrl.dtsi
@@ -415,19 +415,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -435,40 +432,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152ccux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152ccux-pinctrl.dtsi
@@ -415,19 +415,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -435,40 +432,40 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qchx-pinctrl.dtsi
@@ -656,31 +656,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -688,67 +683,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qdhx-pinctrl.dtsi
@@ -656,31 +656,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -688,85 +683,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152qehx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qehx-pinctrl.dtsi
@@ -656,31 +656,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -688,85 +683,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152r(6-8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)hx-pinctrl.dtsi
@@ -374,19 +374,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -394,49 +391,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152r(6-8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)hxa-pinctrl.dtsi
@@ -374,19 +374,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -394,49 +391,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)tx-pinctrl.dtsi
@@ -378,19 +378,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -398,49 +395,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152r(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)txa-pinctrl.dtsi
@@ -378,19 +378,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -398,49 +395,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rctx-pinctrl.dtsi
@@ -479,19 +479,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -499,49 +496,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rctxa-pinctrl.dtsi
@@ -479,19 +479,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -499,49 +496,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rdtx-pinctrl.dtsi
@@ -479,19 +479,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -499,67 +496,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rdyx-pinctrl.dtsi
@@ -479,19 +479,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -499,67 +496,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152retx-pinctrl.dtsi
@@ -479,19 +479,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -499,67 +496,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152ucyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152ucyx-pinctrl.dtsi
@@ -479,19 +479,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -499,49 +496,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)hx-pinctrl.dtsi
@@ -510,31 +510,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -542,67 +537,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152v(8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)hxa-pinctrl.dtsi
@@ -510,31 +510,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -542,67 +537,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)tx-pinctrl.dtsi
@@ -510,31 +510,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -542,67 +537,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152v(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)txa-pinctrl.dtsi
@@ -510,31 +510,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -542,67 +537,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vchx-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,67 +651,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vctx-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,67 +651,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vctxa-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,67 +651,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vdtx-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,85 +651,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152vdtxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vdtxx-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,85 +651,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vetx-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,85 +651,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152veyx-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,85 +651,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zctx-pinctrl.dtsi
@@ -660,31 +660,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -692,67 +687,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zdtx-pinctrl.dtsi
@@ -660,31 +660,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -692,85 +687,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l152zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zetx-pinctrl.dtsi
@@ -660,31 +660,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -692,85 +687,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l162qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162qchx-pinctrl.dtsi
@@ -656,31 +656,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -688,67 +683,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l162qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162qdhx-pinctrl.dtsi
@@ -656,31 +656,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -688,85 +683,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l162rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rctx-pinctrl.dtsi
@@ -479,19 +479,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -499,49 +496,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l162rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rctxa-pinctrl.dtsi
@@ -479,19 +479,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -499,49 +496,49 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l162rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rdtx-pinctrl.dtsi
@@ -479,19 +479,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -499,67 +496,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l162rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rdyx-pinctrl.dtsi
@@ -479,19 +479,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -499,67 +496,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l162retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162retx-pinctrl.dtsi
@@ -479,19 +479,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -499,67 +496,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l162vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vchx-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,67 +651,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l162vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vctx-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,67 +651,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l162vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vctxa-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,67 +651,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l162vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vdtx-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,85 +651,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l162vdyxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vdyxx-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,85 +651,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l162vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vetx-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,85 +651,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l162veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162veyx-pinctrl.dtsi
@@ -624,31 +624,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,85 +651,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l162zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zctx-pinctrl.dtsi
@@ -660,31 +660,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -692,67 +687,67 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l162zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zdtx-pinctrl.dtsi
@@ -660,31 +660,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -692,85 +687,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l1/stm32l162zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zetx-pinctrl.dtsi
@@ -660,31 +660,26 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -692,85 +687,85 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l412c8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412c8tx-pinctrl.dtsi
@@ -462,49 +462,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -512,62 +504,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l412c8ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412c8ux-pinctrl.dtsi
@@ -462,49 +462,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -512,62 +504,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l412cbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbtx-pinctrl.dtsi
@@ -462,49 +462,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -512,62 +504,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l412cbtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbtxp-pinctrl.dtsi
@@ -437,49 +437,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -487,53 +479,54 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l412cbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbux-pinctrl.dtsi
@@ -462,49 +462,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -512,62 +504,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l412cbuxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbuxp-pinctrl.dtsi
@@ -437,49 +437,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -487,53 +479,54 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l412k8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412k8tx-pinctrl.dtsi
@@ -332,25 +332,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -358,44 +354,45 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l412k8ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412k8ux-pinctrl.dtsi
@@ -332,25 +332,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -358,44 +354,45 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l412kbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412kbtx-pinctrl.dtsi
@@ -332,25 +332,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -358,44 +354,45 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l412kbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412kbux-pinctrl.dtsi
@@ -332,25 +332,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -358,44 +354,45 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l412r8ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412r8ix-pinctrl.dtsi
@@ -532,55 +532,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -588,89 +579,90 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l412r8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412r8tx-pinctrl.dtsi
@@ -532,55 +532,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -588,89 +579,90 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l412rbix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbix-pinctrl.dtsi
@@ -532,55 +532,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -588,89 +579,90 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l412rbixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbixp-pinctrl.dtsi
@@ -524,49 +524,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -574,85 +566,85 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l412rbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbtx-pinctrl.dtsi
@@ -532,55 +532,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -588,89 +579,90 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l412rbtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbtxp-pinctrl.dtsi
@@ -524,49 +524,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -574,85 +566,85 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l412t8yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412t8yx-pinctrl.dtsi
@@ -351,25 +351,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -377,48 +373,50 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l412tbyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412tbyx-pinctrl.dtsi
@@ -351,25 +351,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -377,48 +373,50 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l412tbyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412tbyxp-pinctrl.dtsi
@@ -341,25 +341,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -367,48 +363,50 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l422cbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422cbtx-pinctrl.dtsi
@@ -462,49 +462,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -512,62 +504,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l422cbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422cbux-pinctrl.dtsi
@@ -462,49 +462,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -512,62 +504,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l422kbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422kbtx-pinctrl.dtsi
@@ -332,25 +332,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -358,44 +354,45 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l422kbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422kbux-pinctrl.dtsi
@@ -332,25 +332,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -358,44 +354,45 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l422rbix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422rbix-pinctrl.dtsi
@@ -532,55 +532,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -588,89 +579,90 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l422rbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422rbtx-pinctrl.dtsi
@@ -532,55 +532,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -588,89 +579,90 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l422tbyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422tbyx-pinctrl.dtsi
@@ -351,25 +351,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -377,48 +373,50 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l431c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)tx-pinctrl.dtsi
@@ -487,49 +487,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -537,62 +529,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l431c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)ux-pinctrl.dtsi
@@ -487,49 +487,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -537,62 +529,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l431c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)yx-pinctrl.dtsi
@@ -496,49 +496,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -546,62 +538,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l431k(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431k(b-c)ux-pinctrl.dtsi
@@ -348,25 +348,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -374,44 +370,45 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l431r(b-c)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)ix-pinctrl.dtsi
@@ -600,55 +600,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,89 +647,90 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l431r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)tx-pinctrl.dtsi
@@ -600,55 +600,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,89 +647,90 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l431r(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)yx-pinctrl.dtsi
@@ -600,55 +600,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,89 +647,90 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l431vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431vcix-pinctrl.dtsi
@@ -748,67 +748,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -816,107 +805,108 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l431vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431vctx-pinctrl.dtsi
@@ -748,67 +748,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -816,107 +805,108 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l432k(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l432k(b-c)ux-pinctrl.dtsi
@@ -348,25 +348,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -374,44 +370,45 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
@@ -487,49 +487,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -537,62 +529,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
@@ -487,49 +487,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -537,62 +529,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
@@ -496,49 +496,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -546,62 +538,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
@@ -600,55 +600,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,89 +647,90 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
@@ -600,55 +600,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,89 +647,90 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
@@ -600,55 +600,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,89 +647,90 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
@@ -544,49 +544,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -594,85 +586,85 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l433vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vcix-pinctrl.dtsi
@@ -748,67 +748,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -816,107 +805,108 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l433vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vctx-pinctrl.dtsi
@@ -748,67 +748,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -816,107 +805,108 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l442kcux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l442kcux-pinctrl.dtsi
@@ -348,25 +348,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -374,44 +370,45 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l443cctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443cctx-pinctrl.dtsi
@@ -487,49 +487,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -537,62 +529,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l443ccux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccux-pinctrl.dtsi
@@ -487,49 +487,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -537,62 +529,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
@@ -496,49 +496,41 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -546,62 +538,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l443rcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcix-pinctrl.dtsi
@@ -600,55 +600,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,89 +647,90 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l443rctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rctx-pinctrl.dtsi
@@ -600,55 +600,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,89 +647,90 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
@@ -600,55 +600,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -656,89 +647,90 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l443vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vcix-pinctrl.dtsi
@@ -748,67 +748,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -816,107 +805,108 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l443vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vctx-pinctrl.dtsi
@@ -748,67 +748,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -816,107 +805,108 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l451c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451c(c-e)ux-pinctrl.dtsi
@@ -555,55 +555,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -611,71 +602,72 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l451cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451cetx-pinctrl.dtsi
@@ -555,55 +555,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -611,71 +602,72 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l451r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)ix-pinctrl.dtsi
@@ -696,61 +696,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -758,107 +748,108 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l451r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)tx-pinctrl.dtsi
@@ -696,61 +696,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -758,107 +748,108 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l451r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)yx-pinctrl.dtsi
@@ -696,61 +696,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -758,107 +748,108 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l451v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451v(c-e)ix-pinctrl.dtsi
@@ -872,73 +872,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -946,125 +934,126 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l451v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451v(c-e)tx-pinctrl.dtsi
@@ -872,73 +872,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -946,125 +934,126 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l452c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452c(c-e)ux-pinctrl.dtsi
@@ -555,55 +555,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -611,71 +602,72 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l452cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452cetx-pinctrl.dtsi
@@ -555,55 +555,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -611,71 +602,72 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
@@ -696,61 +696,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -758,107 +748,108 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
@@ -696,61 +696,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -758,107 +748,108 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
@@ -696,61 +696,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -758,107 +748,108 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l452retxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452retxp-pinctrl.dtsi
@@ -640,55 +640,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -696,103 +687,103 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
@@ -872,73 +872,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -946,125 +934,126 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
@@ -872,73 +872,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -946,125 +934,126 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l462cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462cetx-pinctrl.dtsi
@@ -555,55 +555,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -611,71 +602,72 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l462ceux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462ceux-pinctrl.dtsi
@@ -555,55 +555,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -611,71 +602,72 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l462reix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reix-pinctrl.dtsi
@@ -696,61 +696,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -758,107 +748,108 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l462retx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462retx-pinctrl.dtsi
@@ -696,61 +696,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -758,107 +748,108 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l462reyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reyx-pinctrl.dtsi
@@ -696,61 +696,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -758,107 +748,108 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l462veix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462veix-pinctrl.dtsi
@@ -872,73 +872,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -946,125 +934,126 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l462vetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462vetx-pinctrl.dtsi
@@ -872,73 +872,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -946,125 +934,126 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
@@ -1347,79 +1347,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1427,139 +1414,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l471r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471r(e-g)tx-pinctrl.dtsi
@@ -756,55 +756,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -812,103 +803,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
@@ -1109,67 +1109,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1177,121 +1166,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
@@ -1391,79 +1391,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1471,139 +1458,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
@@ -1391,79 +1391,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1471,139 +1458,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
@@ -756,55 +756,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -812,103 +803,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
@@ -1109,67 +1109,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1177,121 +1166,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
@@ -806,61 +806,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -868,112 +858,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
@@ -783,61 +783,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -845,108 +835,107 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
@@ -815,67 +815,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -883,130 +872,130 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
@@ -1347,79 +1347,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1427,139 +1414,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
@@ -756,55 +756,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -812,103 +803,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
@@ -1109,67 +1109,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1177,121 +1166,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
@@ -1391,79 +1391,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1471,139 +1458,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
@@ -1391,79 +1391,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1471,139 +1458,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
@@ -1376,79 +1376,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1456,130 +1443,130 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
@@ -806,61 +806,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -868,112 +858,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
@@ -806,61 +806,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -868,112 +858,112 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l486qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486qgix-pinctrl.dtsi
@@ -1347,79 +1347,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1427,139 +1414,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
@@ -756,55 +756,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -812,103 +803,103 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
@@ -1109,67 +1109,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1177,121 +1166,121 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
@@ -1391,79 +1391,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1471,139 +1458,139 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
@@ -1676,91 +1676,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1768,152 +1753,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l496agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496agixp-pinctrl.dtsi
@@ -1672,91 +1672,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1764,152 +1749,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
@@ -1561,91 +1561,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1653,152 +1638,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
@@ -1528,91 +1528,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1620,143 +1605,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
@@ -899,67 +899,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -967,116 +956,117 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
@@ -839,61 +839,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -901,108 +891,107 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
@@ -1299,79 +1299,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1379,134 +1366,135 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
@@ -1268,79 +1268,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1348,125 +1335,126 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
@@ -1252,79 +1252,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1332,143 +1319,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
@@ -1244,79 +1244,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1324,139 +1311,139 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
@@ -1333,85 +1333,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1419,152 +1405,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
@@ -1630,91 +1630,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1722,152 +1707,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
@@ -1609,91 +1609,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1701,143 +1686,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
@@ -1676,91 +1676,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1768,152 +1753,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
@@ -1672,91 +1672,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1764,152 +1749,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
@@ -1561,91 +1561,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1653,152 +1638,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
@@ -1528,91 +1528,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1620,143 +1605,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
@@ -899,67 +899,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -967,116 +956,117 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
@@ -886,61 +886,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -948,108 +938,107 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
@@ -1299,79 +1299,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1379,134 +1366,135 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
@@ -1268,79 +1268,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1348,125 +1335,126 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
@@ -1252,79 +1252,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1332,143 +1319,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
@@ -1244,79 +1244,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1324,139 +1311,139 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
@@ -1630,91 +1630,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1722,152 +1707,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
@@ -1609,91 +1609,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1701,143 +1686,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
@@ -1623,91 +1623,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1715,152 +1700,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
@@ -1619,91 +1619,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1711,152 +1696,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
@@ -642,55 +642,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -698,71 +689,72 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
@@ -642,55 +642,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -698,71 +689,72 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
@@ -602,55 +602,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -658,62 +649,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
@@ -602,55 +602,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -658,62 +649,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
@@ -1522,91 +1522,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1614,152 +1599,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
@@ -1494,91 +1494,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1586,143 +1571,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
@@ -860,61 +860,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -922,107 +912,108 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
@@ -847,55 +847,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -903,103 +894,103 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
@@ -1232,79 +1232,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1312,134 +1299,135 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
@@ -1228,79 +1228,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1308,143 +1295,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
@@ -1206,79 +1206,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1286,125 +1273,126 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
@@ -1220,79 +1220,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1300,139 +1287,139 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
@@ -1546,91 +1546,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1638,152 +1623,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
@@ -1530,91 +1530,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1622,143 +1607,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
@@ -1559,91 +1559,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1651,152 +1636,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
@@ -642,55 +642,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -698,71 +689,72 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
@@ -642,55 +642,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -698,71 +689,72 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
@@ -1522,91 +1522,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1614,152 +1599,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
@@ -860,61 +860,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -922,107 +912,108 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
@@ -1232,79 +1232,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1312,134 +1299,135 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
@@ -1228,79 +1228,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1308,143 +1295,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
@@ -1546,91 +1546,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1638,152 +1623,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
@@ -1444,91 +1444,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1536,152 +1521,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
@@ -1343,91 +1343,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1435,152 +1420,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
@@ -1093,79 +1093,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1173,134 +1160,135 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
@@ -1367,91 +1367,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1459,152 +1444,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
@@ -1328,91 +1328,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1420,152 +1405,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
@@ -1351,91 +1351,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1443,143 +1428,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
@@ -1444,91 +1444,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1536,152 +1521,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
@@ -1093,79 +1093,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1173,134 +1160,135 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
@@ -1367,91 +1367,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1459,152 +1444,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
@@ -1422,91 +1422,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1514,148 +1499,148 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
@@ -1019,73 +1019,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1093,130 +1081,130 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
@@ -1340,91 +1340,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1432,152 +1417,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
@@ -1327,91 +1327,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1419,148 +1404,148 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
@@ -1328,91 +1328,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1420,152 +1405,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
@@ -1300,91 +1300,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1392,143 +1377,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
@@ -1444,91 +1444,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1536,152 +1521,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
@@ -1343,91 +1343,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1435,152 +1420,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
@@ -1093,79 +1093,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1173,134 +1160,135 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
@@ -1367,91 +1367,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1459,152 +1444,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
@@ -1328,91 +1328,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1420,152 +1405,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
@@ -1444,91 +1444,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1536,152 +1521,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
@@ -1093,79 +1093,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1173,134 +1160,135 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
@@ -1367,91 +1367,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1459,152 +1444,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
@@ -1422,91 +1422,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1514,148 +1499,148 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
@@ -1019,73 +1019,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1093,130 +1081,130 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
@@ -1340,91 +1340,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1432,152 +1417,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
@@ -1327,91 +1327,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1419,148 +1404,148 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
@@ -1328,91 +1328,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1420,152 +1405,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_FS */

--- a/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
@@ -598,55 +598,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -654,71 +645,72 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
@@ -598,55 +598,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -654,71 +645,72 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
@@ -559,55 +559,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -615,62 +606,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
@@ -559,55 +559,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -615,62 +606,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
@@ -868,73 +868,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -942,121 +930,121 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
@@ -845,73 +845,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -919,121 +907,121 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
@@ -1364,91 +1364,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1456,152 +1441,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l552qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeix-pinctrl.dtsi
@@ -1403,91 +1403,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1495,152 +1480,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
@@ -1388,91 +1388,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1480,152 +1465,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
@@ -803,67 +803,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -871,116 +860,117 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l552retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxp-pinctrl.dtsi
@@ -718,61 +718,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -780,108 +770,107 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l552retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxq-pinctrl.dtsi
@@ -733,61 +733,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -795,98 +785,99 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
@@ -1122,73 +1122,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1196,125 +1184,126 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l552vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552vetx-pinctrl.dtsi
@@ -1153,79 +1153,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1233,134 +1220,135 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
@@ -1391,85 +1391,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1477,143 +1463,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l552zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552zetx-pinctrl.dtsi
@@ -1427,91 +1427,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1519,152 +1504,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l562cetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetx-pinctrl.dtsi
@@ -598,55 +598,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -654,71 +645,72 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
@@ -559,55 +559,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -615,62 +606,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l562ceux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceux-pinctrl.dtsi
@@ -598,55 +598,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -654,71 +645,72 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
@@ -559,55 +559,46 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -615,62 +606,63 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
@@ -868,73 +868,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -942,121 +930,121 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
@@ -845,73 +845,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -919,121 +907,121 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l562qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeix-pinctrl.dtsi
@@ -1403,91 +1403,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1495,152 +1480,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
@@ -1388,91 +1388,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1480,152 +1465,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
@@ -1364,91 +1364,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1456,152 +1441,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l562retx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retx-pinctrl.dtsi
@@ -803,67 +803,56 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -871,116 +860,117 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l562retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxp-pinctrl.dtsi
@@ -718,61 +718,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -780,108 +770,107 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l562retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxq-pinctrl.dtsi
@@ -733,61 +733,51 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -795,98 +785,99 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l562vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetx-pinctrl.dtsi
@@ -1153,79 +1153,66 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1233,134 +1220,135 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
@@ -1122,73 +1122,61 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1196,125 +1184,126 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l562zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetx-pinctrl.dtsi
@@ -1427,91 +1427,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1519,152 +1504,153 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc5: usart3_rx_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc4: usart3_tx_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
@@ -1391,85 +1391,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pg6: lpuart1_rts_pg6 {
 				pinmux = <STM32_PINMUX('G', 6, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pg12: usart1_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pa15: usart3_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb1: usart3_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd2: usart3_rts_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pb4: uart5_rts_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1477,143 +1463,144 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pg8: lpuart1_rx_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pg10: usart1_rx_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa15: usart2_rx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF3)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pg7: lpuart1_tx_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg9: usart1_tx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
@@ -2481,91 +2481,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2573,296 +2558,297 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
@@ -1844,85 +1844,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1930,247 +1916,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
@@ -2405,91 +2405,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2497,287 +2482,288 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
@@ -1844,85 +1844,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1930,247 +1916,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
@@ -2481,91 +2481,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2573,296 +2558,297 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
@@ -1844,85 +1844,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1930,247 +1916,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
@@ -2405,91 +2405,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2497,287 +2482,288 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
@@ -1844,85 +1844,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1930,247 +1916,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
@@ -2481,91 +2481,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2573,296 +2558,297 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
@@ -1844,85 +1844,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1930,247 +1916,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
@@ -2405,91 +2405,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2497,287 +2482,288 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
@@ -1844,85 +1844,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1930,247 +1916,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
@@ -2481,91 +2481,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2573,296 +2558,297 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
@@ -1844,85 +1844,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1930,247 +1916,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
@@ -2405,91 +2405,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2497,287 +2482,288 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
@@ -1844,85 +1844,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1930,247 +1916,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
@@ -2537,91 +2537,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2629,296 +2614,297 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
@@ -1888,85 +1888,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1974,247 +1960,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
@@ -2461,91 +2461,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2553,287 +2538,288 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
@@ -1888,85 +1888,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1974,247 +1960,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
@@ -2537,91 +2537,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2629,296 +2614,297 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
@@ -1888,85 +1888,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1974,247 +1960,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
@@ -2461,91 +2461,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2553,287 +2538,288 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
@@ -1888,85 +1888,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1974,247 +1960,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
@@ -2537,91 +2537,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2629,296 +2614,297 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
@@ -1888,85 +1888,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1974,247 +1960,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
@@ -2461,91 +2461,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2553,287 +2538,288 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
@@ -1888,85 +1888,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1974,247 +1960,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
@@ -2537,91 +2537,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2629,296 +2614,297 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
@@ -1888,85 +1888,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1974,247 +1960,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
@@ -2461,91 +2461,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2553,287 +2538,288 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
@@ -1888,85 +1888,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1974,247 +1960,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
@@ -2537,91 +2537,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2629,296 +2614,297 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
@@ -1888,85 +1888,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1974,247 +1960,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
@@ -2461,91 +2461,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2553,287 +2538,288 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
@@ -1888,85 +1888,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1974,247 +1960,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
@@ -2537,91 +2537,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2629,296 +2614,297 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
@@ -1888,85 +1888,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1974,247 +1960,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
@@ -2461,91 +2461,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2553,287 +2538,288 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
@@ -1888,85 +1888,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1974,247 +1960,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
@@ -2537,91 +2537,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2629,296 +2614,297 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
@@ -1888,85 +1888,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1974,247 +1960,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
@@ -2461,91 +2461,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2553,287 +2538,288 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
@@ -1888,85 +1888,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1974,247 +1960,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
@@ -2537,91 +2537,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2629,296 +2614,297 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pj9: uart8_rx_pj9 {
 				pinmux = <STM32_PINMUX('J', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pj8: uart8_tx_pj8 {
 				pinmux = <STM32_PINMUX('J', 8, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
@@ -1888,85 +1888,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1974,247 +1960,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
@@ -2461,91 +2461,76 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pz5: usart1_rts_pz5 {
 				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -2553,287 +2538,288 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz1: usart1_rx_pz1 {
 				pinmux = <STM32_PINMUX('Z', 1, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pz6: usart1_rx_pz6 {
 				pinmux = <STM32_PINMUX('Z', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pf4: usart2_rx_pf4 {
 				pinmux = <STM32_PINMUX('F', 4, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_ph14: uart4_rx_ph14 {
 				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pi9: uart4_rx_pi9 {
 				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz2: usart1_tx_pz2 {
 				pinmux = <STM32_PINMUX('Z', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pz7: usart1_tx_pz7 {
 				pinmux = <STM32_PINMUX('Z', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pf5: usart2_tx_pf5 {
 				pinmux = <STM32_PINMUX('F', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_ph13: uart4_tx_ph13 {
 				pinmux = <STM32_PINMUX('H', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
@@ -1888,85 +1888,71 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg8: usart6_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pe9: uart7_rts_pe9 {
 				pinmux = <STM32_PINMUX('E', 9, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart7_rts_pf8: uart7_rts_pf8 {
 				pinmux = <STM32_PINMUX('F', 8, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			uart8_rts_pg7: uart8_rts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -1974,247 +1960,247 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb2: usart1_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF4)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb15: usart1_rx_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF7)>;
+				bias-pull-up;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
 				pinmux = <STM32_PINMUX('D', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pb12: usart3_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+				bias-pull-up;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb2: uart4_rx_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pb8: uart4_rx_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd0: uart4_rx_pd0 {
 				pinmux = <STM32_PINMUX('D', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			uart4_rx_pd2: uart4_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb5: uart5_rx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pb12: uart5_rx_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF14)>;
+				bias-pull-up;
 			};
 
 			uart5_rx_pd2: uart5_rx_pd2 {
 				pinmux = <STM32_PINMUX('D', 2, AF8)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pc7: usart6_rx_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			usart6_rx_pg9: usart6_rx_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pa8: uart7_rx_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pb3: uart7_rx_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			uart7_rx_pf6: uart7_rx_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				bias-pull-up;
 			};
 
 			uart8_rx_pe0: uart8_rx_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb14: usart1_tx_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF4)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pg11: usart1_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF4)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF7)>;
-				bias-pull-up;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
 				pinmux = <STM32_PINMUX('D', 5, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
-				bias-pull-up;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa0: uart4_tx_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa12: uart4_tx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pa13: uart4_tx_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pb9: uart4_tx_pb9 {
 				pinmux = <STM32_PINMUX('B', 9, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc8: uart4_tx_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF6)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pd1: uart4_tx_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			uart4_tx_pg11: uart4_tx_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb6: uart5_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF12)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pb13: uart5_tx_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF14)>;
-				bias-pull-up;
 			};
 
 			uart5_tx_pc12: uart5_tx_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF8)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pc6: usart6_tx_pc6 {
 				pinmux = <STM32_PINMUX('C', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			usart6_tx_pg14: usart6_tx_pg14 {
 				pinmux = <STM32_PINMUX('G', 14, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pa15: uart7_tx_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pb4: uart7_tx_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF13)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
-				bias-pull-up;
 			};
 
 			uart7_tx_pf7: uart7_tx_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF7)>;
-				bias-pull-up;
 			};
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB_OTG_HS */

--- a/dts/st/wb/stm32wb30ceuxa-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb30ceuxa-pinctrl.dtsi
@@ -260,13 +260,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -274,22 +272,22 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/wb/stm32wb35c(c-e)uxa-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb35c(c-e)uxa-pinctrl.dtsi
@@ -310,19 +310,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -330,40 +327,40 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa12: lpuart1_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb5: lpuart1_tx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/wb/stm32wb50cgux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb50cgux-pinctrl.dtsi
@@ -260,13 +260,11 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -274,22 +272,22 @@
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 		};

--- a/dts/st/wb/stm32wb55ccux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55ccux-pinctrl.dtsi
@@ -310,19 +310,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -330,40 +327,40 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa12: lpuart1_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb5: lpuart1_tx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/wb/stm32wb55ceux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55ceux-pinctrl.dtsi
@@ -310,19 +310,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -330,40 +327,40 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa12: lpuart1_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb5: lpuart1_tx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/wb/stm32wb55cgux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55cgux-pinctrl.dtsi
@@ -310,19 +310,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -330,40 +327,40 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa12: lpuart1_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb5: lpuart1_tx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
@@ -466,25 +466,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -492,58 +488,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa12: lpuart1_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb5: lpuart1_tx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/wb/stm32wb55revx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55revx-pinctrl.dtsi
@@ -466,25 +466,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -492,58 +488,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa12: lpuart1_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb5: lpuart1_tx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
@@ -466,25 +466,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -492,58 +488,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa12: lpuart1_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb5: lpuart1_tx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
@@ -522,25 +522,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -548,58 +544,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa12: lpuart1_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb5: lpuart1_tx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
@@ -522,25 +522,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -548,58 +544,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa12: lpuart1_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb5: lpuart1_tx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
@@ -522,25 +522,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -548,58 +544,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa12: lpuart1_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb5: lpuart1_tx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
@@ -522,25 +522,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -548,58 +544,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa12: lpuart1_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb5: lpuart1_tx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
@@ -522,25 +522,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -548,58 +544,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa12: lpuart1_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb5: lpuart1_tx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
@@ -522,25 +522,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -548,58 +544,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa12: lpuart1_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb5: lpuart1_tx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/wb/stm32wb55vyyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vyyx-pinctrl.dtsi
@@ -522,25 +522,21 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -548,58 +544,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa12: lpuart1_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb5: lpuart1_tx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
@@ -522,19 +522,16 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart1_rts_pb3: usart1_rts_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF7)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
 			lpuart1_rts_pb12: lpuart1_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF8)>;
-				bias-pull-up;
 				drive-open-drain;
 			};
 
@@ -542,58 +539,58 @@
 
 			lpuart1_rx_pa3: lpuart1_rx_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pa12: lpuart1_rx_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF8)>;
+				bias-pull-up;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF7)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pb10: lpuart1_rx_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF8)>;
+				bias-pull-up;
 			};
 
 			lpuart1_rx_pc0: lpuart1_rx_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF8)>;
+				bias-pull-up;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb5: lpuart1_tx_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF8)>;
-				bias-pull-up;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF7)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pb11: lpuart1_tx_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF8)>;
-				bias-pull-up;
 			};
 
 			lpuart1_tx_pc1: lpuart1_tx_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF8)>;
-				bias-pull-up;
 			};
 
 			/* USB */

--- a/scripts/genpinctrl/genpinctrl.py
+++ b/scripts/genpinctrl/genpinctrl.py
@@ -456,7 +456,7 @@ def main(data_path, output):
         config_f1 = yaml.load(f, Loader=yaml.Loader)
 
     env = Environment(
-        trim_blocks=True, lstrip_blocks=True, loader=FileSystemLoader(SCRIPT_DIR)
+        trim_blocks=True, lstrip_blocks=True, loader=FileSystemLoader(str(SCRIPT_DIR))
     )
     env.filters["format_mode"] = format_mode
     env.filters["format_mode_f1"] = format_mode_f1

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -195,14 +195,13 @@
 - name: UART_RTS / USART_RTS / LPUART_RTS
   match: "^(?:LP)?US?ART\\d+_RTS$"
   drive: open-drain
-  bias: pull-up
 
 - name: UART_TX / USART_TX / LPUART_TX
   match: "^(?:LP)?US?ART\\d+_TX$"
-  bias: pull-up
 
 - name: UART_RX / USART_RX / LPUART_RX
   match: "^(?:LP)?US?ART\\d+_RX$"
+  bias: pull-up
 
 - name: USB_OTG_FS
   match: "^USB_OTG_FS_(?:DM)?(?:DP)?(?:SOF)?(?:ID)?(?:VBUS)?$"

--- a/scripts/genpinctrl/stm32f1-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32f1-pinctrl-config.yaml
@@ -224,6 +224,7 @@
 - name: UART_RX / USART_RX
   match: "^US?ART\\d+_RX$"
   mode: input
+  bias: pull-up
 
 - name: USB_OTG_FS
   match: "^USB_OTG_FS_(?:DM)?(?:DP)?(?:SOF)?(?:ID)?(?:VBUS)?$"


### PR DESCRIPTION
Use pull-up on inputs and remove it from outputs.
In the past, it was done intentionally since the
pinmux was configured before the uart driver. Now,
it is configured inside the uart driver using `pinctrl-0`
property.

Fixes: #https://github.com/zephyrproject-rtos/zephyr/issues/15349