### PR TITLE
scripts: update_sm32_package: Fix issue with common_ll directory

### DIFF
--- a/scripts/README.rst
+++ b/scripts/README.rst
@@ -18,6 +18,8 @@ Alternatively, in order to update STM32CubeXX versions one by one, run for examp
 
     $ python3 ./update_stm32_package.py -s stm32f1
 
+Note: This requires $ZEPHYR_BASE is set in your environment.
+
 Check STM32CubeXX changes
 =========================
 

--- a/scripts/update_stm32_package.py
+++ b/scripts/update_stm32_package.py
@@ -70,7 +70,7 @@ def update_cubes():
         raise Exception("Error: cannot find ./zephyr project")
 
     for stmyyxx in module_path.iterdir():
-        if stmyyxx.is_dir():
+        if stmyyxx.is_dir() and "common_ll" not in stmyyxx.name:
             logging.info("updating module " + stmyyxx.name)
             # Force the commit for each serie
             update_serie = serie_update.Stm32SerieUpdate(


### PR DESCRIPTION
When running ./update_stm32_package.py, script breaks due to
unexpected presence of common_ll/ under stm32cube/ .
Skip update when this directory is parsed.

Additionally, update README to avoid recurrent issue when using
the script.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>