### PR TITLE
dts: Add slew-rate properties to stm32f1 series's SPI & I2S clock pins

### DIFF
--- a/dts/st/f1/stm32f100c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100c(4-6)tx-pinctrl.dtsi
@@ -122,10 +122,12 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -164,10 +166,12 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f100c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100c(8-b)tx-pinctrl.dtsi
@@ -145,14 +145,17 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -204,14 +207,17 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f100r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(4-6)hx-pinctrl.dtsi
@@ -142,10 +142,12 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -184,10 +186,12 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f100r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(4-6)tx-pinctrl.dtsi
@@ -146,10 +146,12 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -188,10 +190,12 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f100r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(8-b)hx-pinctrl.dtsi
@@ -165,14 +165,17 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -224,14 +227,17 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f100r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(8-b)tx-pinctrl.dtsi
@@ -169,14 +169,17 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -228,14 +231,17 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f100r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(c-d-e)tx-pinctrl.dtsi
@@ -182,18 +182,22 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -258,18 +262,22 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f100v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100v(8-b)tx-pinctrl.dtsi
@@ -169,14 +169,17 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -228,14 +231,17 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f100v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100v(c-d-e)tx-pinctrl.dtsi
@@ -182,18 +182,22 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -258,18 +262,22 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f100z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100z(c-d-e)tx-pinctrl.dtsi
@@ -182,18 +182,22 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -258,18 +262,22 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f101c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(4-6)tx-pinctrl.dtsi
@@ -112,10 +112,12 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -154,10 +156,12 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f101c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(8-b)tx-pinctrl.dtsi
@@ -135,14 +135,17 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -194,14 +197,17 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f101c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(8-b)ux-pinctrl.dtsi
@@ -135,14 +135,17 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -194,14 +197,17 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f101r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(4-6)tx-pinctrl.dtsi
@@ -136,10 +136,12 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -178,10 +180,12 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f101r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(8-b)tx-pinctrl.dtsi
@@ -159,14 +159,17 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -218,14 +221,17 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f101r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(c-d-e)tx-pinctrl.dtsi
@@ -182,18 +182,22 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -258,18 +262,22 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f101r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(f-g)tx-pinctrl.dtsi
@@ -182,18 +182,22 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -258,18 +262,22 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f101rbhx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101rbhx-pinctrl.dtsi
@@ -155,14 +155,17 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -214,14 +217,17 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f101t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101t(4-6)ux-pinctrl.dtsi
@@ -102,10 +102,12 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -144,10 +146,12 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f101t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101t(8-b)ux-pinctrl.dtsi
@@ -102,10 +102,12 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -144,10 +146,12 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f101v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(8-b)tx-pinctrl.dtsi
@@ -159,14 +159,17 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -218,14 +221,17 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f101v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(c-d-e)tx-pinctrl.dtsi
@@ -182,18 +182,22 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -258,18 +262,22 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f101v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(f-g)tx-pinctrl.dtsi
@@ -182,18 +182,22 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -258,18 +262,22 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f101z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101z(c-d-e)tx-pinctrl.dtsi
@@ -182,18 +182,22 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -258,18 +262,22 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f101z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101z(f-g)tx-pinctrl.dtsi
@@ -182,18 +182,22 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -258,18 +262,22 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
@@ -112,10 +112,12 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -154,10 +156,12 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
@@ -135,14 +135,17 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -194,14 +197,17 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
@@ -136,10 +136,12 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -178,10 +180,12 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
@@ -159,14 +159,17 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -218,14 +221,17 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
@@ -172,10 +172,12 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -214,10 +216,12 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
@@ -195,14 +195,17 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -254,14 +257,17 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
@@ -172,10 +172,12 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -214,10 +216,12 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103cbux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103cbux-pinctrl.dtsi
@@ -195,14 +195,17 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -254,14 +257,17 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
@@ -212,10 +212,12 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -254,10 +256,12 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
@@ -220,10 +220,12 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -262,10 +264,12 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
@@ -235,14 +235,17 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -294,14 +297,17 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
@@ -243,14 +243,17 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -302,14 +305,17 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
@@ -240,10 +240,12 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* I2S_SD */
@@ -328,18 +330,22 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -404,18 +410,22 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
@@ -228,10 +228,12 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* I2S_SD */
@@ -316,18 +318,22 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -392,18 +398,22 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
@@ -240,10 +240,12 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* I2S_SD */
@@ -328,18 +330,22 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -404,18 +410,22 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
@@ -154,10 +154,12 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -196,10 +198,12 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
@@ -154,10 +154,12 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -196,10 +198,12 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
@@ -251,14 +251,17 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -310,14 +313,17 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
@@ -251,14 +251,17 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -310,14 +313,17 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
@@ -248,10 +248,12 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* I2S_SD */
@@ -336,18 +338,22 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -412,18 +418,22 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
@@ -248,10 +248,12 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* I2S_SD */
@@ -336,18 +338,22 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -412,18 +418,22 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
@@ -248,10 +248,12 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* I2S_SD */
@@ -336,18 +338,22 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -412,18 +418,22 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103vbix-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103vbix-pinctrl.dtsi
@@ -251,14 +251,17 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -310,14 +313,17 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
@@ -268,10 +268,12 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* I2S_SD */
@@ -356,18 +358,22 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -432,18 +438,22 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
@@ -268,10 +268,12 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* I2S_SD */
@@ -356,18 +358,22 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -432,18 +438,22 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
@@ -268,10 +268,12 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* I2S_SD */
@@ -356,18 +358,22 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -432,18 +438,22 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
@@ -268,10 +268,12 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* I2S_SD */
@@ -356,18 +358,22 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -432,18 +438,22 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
@@ -224,14 +224,17 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* I2S_SD */
@@ -337,22 +340,27 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pc10: spi3_sck_master_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -430,22 +438,27 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pc10: spi3_sck_slave_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
@@ -232,14 +232,17 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* I2S_SD */
@@ -345,22 +348,27 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pc10: spi3_sck_master_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -438,22 +446,27 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pc10: spi3_sck_slave_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
@@ -232,14 +232,17 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* I2S_SD */
@@ -345,22 +348,27 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pc10: spi3_sck_master_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -438,22 +446,27 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pc10: spi3_sck_slave_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
@@ -342,14 +342,17 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* I2S_SD */
@@ -455,22 +458,27 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pc10: spi3_sck_master_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -548,22 +556,27 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pc10: spi3_sck_slave_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
@@ -374,14 +374,17 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* I2S_SD */
@@ -487,22 +490,27 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pc10: spi3_sck_master_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -580,22 +588,27 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pc10: spi3_sck_slave_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/dts/st/f1/stm32f107vchx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107vchx-pinctrl.dtsi
@@ -374,14 +374,17 @@
 
 			i2s2_ck_pb13: i2s2_ck_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			i2s3_ck_pc10: i2s3_ck_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* I2S_SD */
@@ -487,22 +490,27 @@
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_master_pc10: spi3_sck_master_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* SPI_SLAVE_MISO */
@@ -580,22 +588,27 @@
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			spi3_sck_slave_pc10: spi3_sck_slave_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, REMAP_1)>;
+				slew-rate = "max-speed-50mhz";
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */

--- a/scripts/genpinctrl/stm32f1-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32f1-pinctrl-config.yaml
@@ -151,6 +151,7 @@
 - name: I2S_CK
   match: "^I2S\\d+_CK$"
   mode: alternate
+  slew-rate: max-speed-50mhz
 
 - name: I2S_WS
   match: "^I2S\\d+_WS$"
@@ -175,6 +176,7 @@
   match: "^SPI\\d+_SCK$"
   mode: alternate
   variant: master
+  slew-rate: max-speed-50mhz
 
 - name: SPI_MASTER_NSS
   match: "^SPI\\d+_NSS$"
@@ -195,6 +197,7 @@
   match: "^SPI\\d+_SCK$"
   mode: input
   variant: slave
+  slew-rate: max-speed-50mhz
 
 - name: SPI_SLAVE_NSS
   match: "^SPI\\d+_NSS$"


### PR DESCRIPTION
Unlike other STM32 SOC (eg: F4, F7), the clock pins of SPI & I2S of STM32F1 series don't have the slew-rate properties defined, causing at least the SPI to not work if not defined in devicetree specifically. This pull request is to fix this issue after being enlightened by @erwango in Slack.

However, I've only tested the SPI1 for a SPI-NOR flash on my STM32F103RET6 custom board. I2S and other SPI port are not tested.