### PR TITLE
Fix SPI pin configuration to reduce power consumption in STOP mode

### DIFF
--- a/dts/st/f0/stm32f030c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030c6tx-pinctrl.dtsi
@@ -171,16 +171,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb13: spi1_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f030c8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030c8tx-pinctrl.dtsi
@@ -159,16 +159,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f030cctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030cctx-pinctrl.dtsi
@@ -200,21 +200,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f030f4px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030f4px-pinctrl.dtsi
@@ -89,6 +89,7 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f030k6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030k6tx-pinctrl.dtsi
@@ -120,11 +120,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f030r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030r8tx-pinctrl.dtsi
@@ -183,16 +183,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f030rctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030rctx-pinctrl.dtsi
@@ -234,21 +234,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f031c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031c(4-6)tx-pinctrl.dtsi
@@ -203,16 +203,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb13: spi1_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f031e6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031e6yx-pinctrl.dtsi
@@ -133,6 +133,7 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f031f(4-6)px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031f(4-6)px-pinctrl.dtsi
@@ -108,6 +108,7 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f031g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031g(4-6)ux-pinctrl.dtsi
@@ -152,11 +152,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f031k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031k(4-6)ux-pinctrl.dtsi
@@ -158,11 +158,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f031k6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031k6tx-pinctrl.dtsi
@@ -152,11 +152,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f038c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038c6tx-pinctrl.dtsi
@@ -203,16 +203,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb13: spi1_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f038e6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038e6yx-pinctrl.dtsi
@@ -133,6 +133,7 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f038f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038f6px-pinctrl.dtsi
@@ -104,6 +104,7 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f038g6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038g6ux-pinctrl.dtsi
@@ -148,11 +148,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f038k6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038k6ux-pinctrl.dtsi
@@ -158,11 +158,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f042c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042c(4-6)tx-pinctrl.dtsi
@@ -254,21 +254,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f042c(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042c(4-6)ux-pinctrl.dtsi
@@ -254,21 +254,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f042f4px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042f4px-pinctrl.dtsi
@@ -150,6 +150,7 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f042f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042f6px-pinctrl.dtsi
@@ -150,6 +150,7 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f042g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042g(4-6)ux-pinctrl.dtsi
@@ -194,11 +194,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f042k(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042k(4-6)tx-pinctrl.dtsi
@@ -200,11 +200,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f042k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042k(4-6)ux-pinctrl.dtsi
@@ -200,11 +200,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f042t6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042t6yx-pinctrl.dtsi
@@ -200,11 +200,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f048c6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048c6ux-pinctrl.dtsi
@@ -232,21 +232,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f048g6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048g6ux-pinctrl.dtsi
@@ -172,11 +172,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f048t6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048t6yx-pinctrl.dtsi
@@ -182,11 +182,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f051c4tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c4tx-pinctrl.dtsi
@@ -158,11 +158,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f051c4ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c4ux-pinctrl.dtsi
@@ -158,11 +158,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f051c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c6tx-pinctrl.dtsi
@@ -158,11 +158,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f051c6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c6ux-pinctrl.dtsi
@@ -158,11 +158,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f051c8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c8tx-pinctrl.dtsi
@@ -197,16 +197,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f051c8ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c8ux-pinctrl.dtsi
@@ -197,16 +197,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f051k4tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k4tx-pinctrl.dtsi
@@ -146,11 +146,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f051k4ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k4ux-pinctrl.dtsi
@@ -152,11 +152,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f051k6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k6tx-pinctrl.dtsi
@@ -146,11 +146,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f051k6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k6ux-pinctrl.dtsi
@@ -152,11 +152,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f051k8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k8tx-pinctrl.dtsi
@@ -146,11 +146,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f051k8ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k8ux-pinctrl.dtsi
@@ -152,11 +152,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f051r4tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r4tx-pinctrl.dtsi
@@ -197,16 +197,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f051r6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r6tx-pinctrl.dtsi
@@ -197,16 +197,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f051r8hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r8hx-pinctrl.dtsi
@@ -221,16 +221,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f051r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r8tx-pinctrl.dtsi
@@ -221,16 +221,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f051t8yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051t8yx-pinctrl.dtsi
@@ -146,11 +146,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f058c8ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058c8ux-pinctrl.dtsi
@@ -197,16 +197,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f058r8hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058r8hx-pinctrl.dtsi
@@ -221,16 +221,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f058r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058r8tx-pinctrl.dtsi
@@ -221,16 +221,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f058t8yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058t8yx-pinctrl.dtsi
@@ -146,11 +146,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f070c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070c6tx-pinctrl.dtsi
@@ -144,11 +144,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f070cbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070cbtx-pinctrl.dtsi
@@ -164,21 +164,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f070f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070f6px-pinctrl.dtsi
@@ -107,6 +107,7 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f070rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070rbtx-pinctrl.dtsi
@@ -198,21 +198,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f071c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071c(8-b)tx-pinctrl.dtsi
@@ -228,21 +228,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f071c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071c(8-b)ux-pinctrl.dtsi
@@ -228,21 +228,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f071cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071cbyx-pinctrl.dtsi
@@ -228,21 +228,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f071rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071rbtx-pinctrl.dtsi
@@ -266,21 +266,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f071v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071v(8-b)hx-pinctrl.dtsi
@@ -322,31 +322,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f071v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071v(8-b)tx-pinctrl.dtsi
@@ -322,31 +322,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f072c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072c(8-b)tx-pinctrl.dtsi
@@ -250,21 +250,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f072c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072c(8-b)ux-pinctrl.dtsi
@@ -250,21 +250,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f072cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072cbyx-pinctrl.dtsi
@@ -250,21 +250,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f072r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072r(8-b)tx-pinctrl.dtsi
@@ -288,21 +288,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f072rbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072rbhx-pinctrl.dtsi
@@ -288,21 +288,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f072rbix-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072rbix-pinctrl.dtsi
@@ -288,21 +288,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f072v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072v(8-b)hx-pinctrl.dtsi
@@ -353,31 +353,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f072v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072v(8-b)tx-pinctrl.dtsi
@@ -353,31 +353,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f078cbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbtx-pinctrl.dtsi
@@ -228,21 +228,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f078cbux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbux-pinctrl.dtsi
@@ -228,21 +228,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f078cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbyx-pinctrl.dtsi
@@ -228,21 +228,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f078rbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078rbhx-pinctrl.dtsi
@@ -266,21 +266,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f078rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078rbtx-pinctrl.dtsi
@@ -266,21 +266,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f078vbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078vbhx-pinctrl.dtsi
@@ -322,31 +322,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f078vbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078vbtx-pinctrl.dtsi
@@ -322,31 +322,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f091c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091c(b-c)tx-pinctrl.dtsi
@@ -286,21 +286,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f091c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091c(b-c)ux-pinctrl.dtsi
@@ -286,21 +286,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f091r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091r(b-c)tx-pinctrl.dtsi
@@ -324,21 +324,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f091rchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091rchx-pinctrl.dtsi
@@ -324,21 +324,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f091rcyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091rcyx-pinctrl.dtsi
@@ -324,21 +324,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f091v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091v(b-c)tx-pinctrl.dtsi
@@ -389,31 +389,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f091vchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091vchx-pinctrl.dtsi
@@ -389,31 +389,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f098cctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098cctx-pinctrl.dtsi
@@ -286,21 +286,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f098ccux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098ccux-pinctrl.dtsi
@@ -286,21 +286,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f098rchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rchx-pinctrl.dtsi
@@ -324,21 +324,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f098rctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rctx-pinctrl.dtsi
@@ -324,21 +324,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f098rcyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rcyx-pinctrl.dtsi
@@ -324,21 +324,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f098vchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098vchx-pinctrl.dtsi
@@ -389,31 +389,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f0/stm32f098vctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098vctx-pinctrl.dtsi
@@ -389,31 +389,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f2/stm32f205r(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205r(b-c-e-f-g)tx-pinctrl.dtsi
@@ -410,31 +410,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f2/stm32f205r(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205r(e-g)yx-pinctrl.dtsi
@@ -410,31 +410,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f2/stm32f205rgex-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205rgex-pinctrl.dtsi
@@ -410,31 +410,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
@@ -419,31 +419,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
@@ -463,31 +463,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
@@ -709,36 +709,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
@@ -709,36 +709,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
@@ -564,31 +564,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
@@ -628,31 +628,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f2/stm32f215r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215r(e-g)tx-pinctrl.dtsi
@@ -410,31 +410,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
@@ -419,31 +419,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
@@ -463,31 +463,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
@@ -709,36 +709,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
@@ -709,36 +709,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
@@ -564,31 +564,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
@@ -628,31 +628,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f301c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301c(6-8)tx-pinctrl.dtsi
@@ -247,16 +247,19 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f301c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301c8yx-pinctrl.dtsi
@@ -247,16 +247,19 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f301k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301k(6-8)tx-pinctrl.dtsi
@@ -199,11 +199,13 @@
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f301k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301k(6-8)ux-pinctrl.dtsi
@@ -195,11 +195,13 @@
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f301r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301r(6-8)tx-pinctrl.dtsi
@@ -288,21 +288,25 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f302c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c(6-8)tx-pinctrl.dtsi
@@ -269,16 +269,19 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f302c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c(b-c)tx-pinctrl.dtsi
@@ -251,21 +251,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f302c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c8yx-pinctrl.dtsi
@@ -269,16 +269,19 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f302k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302k(6-8)ux-pinctrl.dtsi
@@ -208,11 +208,13 @@
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f302r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(6-8)tx-pinctrl.dtsi
@@ -310,21 +310,25 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f302r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(b-c)tx-pinctrl.dtsi
@@ -314,26 +314,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f302r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(d-e)tx-pinctrl.dtsi
@@ -364,31 +364,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f302v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(b-c)tx-pinctrl.dtsi
@@ -342,36 +342,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
@@ -627,51 +627,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
@@ -627,51 +627,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f302vcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302vcyx-pinctrl.dtsi
@@ -338,36 +338,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
@@ -751,51 +751,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f303c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c(6-8)tx-pinctrl.dtsi
@@ -188,11 +188,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f303c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c(b-c)tx-pinctrl.dtsi
@@ -279,21 +279,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f303c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c8yx-pinctrl.dtsi
@@ -204,11 +204,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f303k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303k(6-8)tx-pinctrl.dtsi
@@ -147,11 +147,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f303k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303k(6-8)ux-pinctrl.dtsi
@@ -143,11 +143,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f303r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(6-8)tx-pinctrl.dtsi
@@ -228,11 +228,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f303r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(b-c)tx-pinctrl.dtsi
@@ -342,26 +342,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f303r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(d-e)tx-pinctrl.dtsi
@@ -392,31 +392,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f303v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(b-c)tx-pinctrl.dtsi
@@ -458,36 +458,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
@@ -743,51 +743,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
@@ -743,51 +743,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f303vcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303vcyx-pinctrl.dtsi
@@ -430,36 +430,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f303veyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303veyx-pinctrl.dtsi
@@ -509,51 +509,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
@@ -867,51 +867,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f318c8tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318c8tx-pinctrl.dtsi
@@ -247,16 +247,19 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f318c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318c8yx-pinctrl.dtsi
@@ -247,16 +247,19 @@
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f318k8ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318k8ux-pinctrl.dtsi
@@ -189,11 +189,13 @@
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f328c8tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f328c8tx-pinctrl.dtsi
@@ -184,11 +184,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f334c(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334c(4-6-8)tx-pinctrl.dtsi
@@ -270,11 +270,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f334c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334c8yx-pinctrl.dtsi
@@ -286,11 +286,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f334k(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334k(4-6-8)tx-pinctrl.dtsi
@@ -201,11 +201,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f334k(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334k(4-6-8)ux-pinctrl.dtsi
@@ -193,11 +193,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f334r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334r(6-8)tx-pinctrl.dtsi
@@ -330,11 +330,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f358cctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358cctx-pinctrl.dtsi
@@ -275,21 +275,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f358rctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358rctx-pinctrl.dtsi
@@ -338,26 +338,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f358vctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358vctx-pinctrl.dtsi
@@ -454,36 +454,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f373c(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373c(8-b-c)tx-pinctrl.dtsi
@@ -377,41 +377,49 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa12: spi1_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd8: spi2_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pa1: spi3_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f373r(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373r(8-b-c)tx-pinctrl.dtsi
@@ -475,51 +475,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa12: spi1_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pc7: spi1_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd8: spi2_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pa1: spi3_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f373v(8-b-c)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373v(8-b-c)hx-pinctrl.dtsi
@@ -511,61 +511,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa12: spi1_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pc7: spi1_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd7: spi2_sck_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd8: spi2_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pa1: spi3_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f373v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373v(8-b-c)tx-pinctrl.dtsi
@@ -511,61 +511,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa12: spi1_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pc7: spi1_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd7: spi2_sck_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd8: spi2_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pa1: spi3_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f378cctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378cctx-pinctrl.dtsi
@@ -377,41 +377,49 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa12: spi1_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd8: spi2_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pa1: spi3_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f378rctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378rctx-pinctrl.dtsi
@@ -475,51 +475,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa12: spi1_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pc7: spi1_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd8: spi2_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pa1: spi3_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f378rcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378rcyx-pinctrl.dtsi
@@ -475,51 +475,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa12: spi1_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pc7: spi1_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd8: spi2_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pa1: spi3_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f378vchx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378vchx-pinctrl.dtsi
@@ -511,61 +511,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa12: spi1_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pc7: spi1_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd7: spi2_sck_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd8: spi2_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pa1: spi3_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f378vctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378vctx-pinctrl.dtsi
@@ -511,61 +511,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa12: spi1_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pc7: spi1_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd7: spi2_sck_pd7 {
 				pinmux = <STM32_PINMUX('D', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd8: spi2_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pa1: spi3_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f3/stm32f398vetx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f398vetx-pinctrl.dtsi
@@ -739,51 +739,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f401c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(b-c)ux-pinctrl.dtsi
@@ -229,26 +229,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f401c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(b-c)yx-pinctrl.dtsi
@@ -229,26 +229,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f401c(d-e)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(d-e)ux-pinctrl.dtsi
@@ -229,26 +229,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f401c(d-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(d-e)yx-pinctrl.dtsi
@@ -229,26 +229,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f401ccfx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401ccfx-pinctrl.dtsi
@@ -229,26 +229,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f401r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401r(b-c)tx-pinctrl.dtsi
@@ -292,31 +292,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f401r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401r(d-e)tx-pinctrl.dtsi
@@ -292,31 +292,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f401v(b-c)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(b-c)hx-pinctrl.dtsi
@@ -342,46 +342,55 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f401v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(b-c)tx-pinctrl.dtsi
@@ -336,46 +336,55 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f401v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(d-e)hx-pinctrl.dtsi
@@ -342,46 +342,55 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f401v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(d-e)tx-pinctrl.dtsi
@@ -336,46 +336,55 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f405o(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405o(e-g)yx-pinctrl.dtsi
@@ -427,36 +427,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f405rgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405rgtx-pinctrl.dtsi
@@ -432,31 +432,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
@@ -441,31 +441,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
@@ -485,31 +485,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
@@ -736,36 +736,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
@@ -736,36 +736,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
@@ -586,31 +586,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
@@ -650,31 +650,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f410c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410c(8-b)tx-pinctrl.dtsi
@@ -234,26 +234,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f410c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410c(8-b)ux-pinctrl.dtsi
@@ -255,26 +255,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f410r(8-b)ix-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410r(8-b)ix-pinctrl.dtsi
@@ -304,31 +304,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f410r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410r(8-b)tx-pinctrl.dtsi
@@ -304,31 +304,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f410t(8-b)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410t(8-b)yx-pinctrl.dtsi
@@ -117,11 +117,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f411c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411c(c-e)ux-pinctrl.dtsi
@@ -337,41 +337,49 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f411c(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411c(c-e)yx-pinctrl.dtsi
@@ -337,41 +337,49 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f411r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411r(c-e)tx-pinctrl.dtsi
@@ -405,51 +405,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f411v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411v(c-e)hx-pinctrl.dtsi
@@ -537,76 +537,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe2: spi5_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe12: spi5_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f411v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411v(c-e)tx-pinctrl.dtsi
@@ -531,76 +531,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe2: spi5_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe12: spi5_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f412c(e-g)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412c(e-g)ux-pinctrl.dtsi
@@ -377,41 +377,49 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f412r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)tx-pinctrl.dtsi
@@ -507,51 +507,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f412r(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)yx-pinctrl.dtsi
@@ -507,51 +507,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f412r(e-g)yxp-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)yxp-pinctrl.dtsi
@@ -507,51 +507,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f412v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412v(e-g)hx-pinctrl.dtsi
@@ -693,76 +693,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe2: spi5_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe12: spi5_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f412v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412v(e-g)tx-pinctrl.dtsi
@@ -687,76 +687,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe2: spi5_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe12: spi5_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f412z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412z(e-g)jx-pinctrl.dtsi
@@ -758,76 +758,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe2: spi5_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe12: spi5_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f412z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412z(e-g)tx-pinctrl.dtsi
@@ -758,76 +758,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe2: spi5_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe12: spi5_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f413c(g-h)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413c(g-h)ux-pinctrl.dtsi
@@ -433,46 +433,55 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f413m(g-h)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413m(g-h)yx-pinctrl.dtsi
@@ -634,66 +634,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe12: spi5_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f413r(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413r(g-h)tx-pinctrl.dtsi
@@ -563,56 +563,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
@@ -749,81 +749,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe2: spi5_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe12: spi5_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
@@ -743,81 +743,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe2: spi5_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe12: spi5_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
@@ -814,81 +814,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe2: spi5_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe12: spi5_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
@@ -814,81 +814,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe2: spi5_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe12: spi5_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f415ogyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415ogyx-pinctrl.dtsi
@@ -427,36 +427,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f415rgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415rgtx-pinctrl.dtsi
@@ -432,31 +432,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
@@ -441,31 +441,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
@@ -485,31 +485,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
@@ -736,36 +736,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
@@ -736,36 +736,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
@@ -586,31 +586,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
@@ -650,31 +650,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f423chux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423chux-pinctrl.dtsi
@@ -433,46 +433,55 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f423mhyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423mhyx-pinctrl.dtsi
@@ -634,66 +634,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe12: spi5_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f423rhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423rhtx-pinctrl.dtsi
@@ -563,56 +563,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
@@ -749,81 +749,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe2: spi5_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe12: spi5_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
@@ -743,81 +743,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe2: spi5_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe12: spi5_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
@@ -814,81 +814,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe2: spi5_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe12: spi5_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
@@ -814,81 +814,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb12: spi3_sck_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pb13: spi4_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pb0: spi5_sck_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe2: spi5_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pe12: spi5_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
@@ -1251,56 +1251,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
@@ -1331,66 +1331,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
@@ -1331,66 +1331,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
@@ -854,46 +854,55 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
@@ -1097,56 +1097,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
@@ -1251,56 +1251,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
@@ -1331,66 +1331,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
@@ -1331,66 +1331,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
@@ -1331,66 +1331,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f429iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429iitx-pinctrl.dtsi
@@ -1331,66 +1331,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
@@ -1331,66 +1331,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f429nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429nihx-pinctrl.dtsi
@@ -1331,66 +1331,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
@@ -824,46 +824,55 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f429vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429vitx-pinctrl.dtsi
@@ -824,46 +824,55 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
@@ -1097,56 +1097,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
@@ -1097,56 +1097,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f429zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zitx-pinctrl.dtsi
@@ -1097,56 +1097,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
@@ -1097,56 +1097,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f437aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437aihx-pinctrl.dtsi
@@ -1251,56 +1251,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
@@ -1331,66 +1331,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
@@ -1331,66 +1331,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
@@ -854,46 +854,55 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
@@ -1097,56 +1097,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f439aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439aihx-pinctrl.dtsi
@@ -1251,56 +1251,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
@@ -1331,66 +1331,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
@@ -1331,66 +1331,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
@@ -1331,66 +1331,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
@@ -1331,66 +1331,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
@@ -824,46 +824,55 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
@@ -1097,56 +1097,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
@@ -1097,56 +1097,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
@@ -605,46 +605,55 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
@@ -557,41 +557,49 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
@@ -920,56 +920,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
@@ -1164,61 +1164,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pg11: spi4_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
@@ -1164,61 +1164,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pg11: spi4_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
@@ -1164,61 +1164,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pc7: spi2_sck_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pg11: spi4_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
@@ -1123,61 +1123,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
@@ -1123,61 +1123,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
@@ -1491,71 +1491,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
@@ -1422,71 +1422,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
@@ -1422,71 +1422,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f469iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469iitx-pinctrl.dtsi
@@ -1422,71 +1422,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
@@ -1491,71 +1491,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f469nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469nihx-pinctrl.dtsi
@@ -1491,71 +1491,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
@@ -700,51 +700,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f469vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469vitx-pinctrl.dtsi
@@ -700,51 +700,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
@@ -977,51 +977,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f469zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469zitx-pinctrl.dtsi
@@ -977,51 +977,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
@@ -1123,61 +1123,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
@@ -1123,61 +1123,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
@@ -1491,71 +1491,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
@@ -1422,71 +1422,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
@@ -1422,71 +1422,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
@@ -1491,71 +1491,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
@@ -700,51 +700,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
@@ -977,51 +977,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
@@ -1441,66 +1441,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
@@ -1441,66 +1441,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
@@ -548,36 +548,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
@@ -941,51 +941,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
@@ -1217,56 +1217,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
@@ -1411,66 +1411,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
@@ -1411,66 +1411,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f723v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)tx-pinctrl.dtsi
@@ -859,51 +859,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
@@ -859,51 +859,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
@@ -1187,56 +1187,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
@@ -1187,56 +1187,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
@@ -1411,66 +1411,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
@@ -548,36 +548,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
@@ -941,51 +941,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
@@ -1187,56 +1187,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f732iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732iekx-pinctrl.dtsi
@@ -1441,66 +1441,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f732ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732ietx-pinctrl.dtsi
@@ -1441,66 +1441,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f732retx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732retx-pinctrl.dtsi
@@ -548,36 +548,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f732vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732vetx-pinctrl.dtsi
@@ -941,51 +941,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f732zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732zetx-pinctrl.dtsi
@@ -1217,56 +1217,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f733iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733iekx-pinctrl.dtsi
@@ -1411,66 +1411,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f733ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733ietx-pinctrl.dtsi
@@ -1411,66 +1411,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f733vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733vetx-pinctrl.dtsi
@@ -859,51 +859,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f733veyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733veyx-pinctrl.dtsi
@@ -859,51 +859,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f733zeix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zeix-pinctrl.dtsi
@@ -1187,56 +1187,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f733zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zetx-pinctrl.dtsi
@@ -1187,56 +1187,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
@@ -1619,71 +1619,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
@@ -1619,71 +1619,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
@@ -1066,51 +1066,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
@@ -1066,51 +1066,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
@@ -1363,61 +1363,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
@@ -1619,71 +1619,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
@@ -1619,71 +1619,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f746ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746ietx-pinctrl.dtsi
@@ -1619,71 +1619,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f746igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746igtx-pinctrl.dtsi
@@ -1619,71 +1619,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f746nehx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nehx-pinctrl.dtsi
@@ -1619,71 +1619,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f746nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nghx-pinctrl.dtsi
@@ -1619,71 +1619,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
@@ -1066,51 +1066,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f746vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vetx-pinctrl.dtsi
@@ -1066,51 +1066,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
@@ -1066,51 +1066,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
@@ -1363,61 +1363,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f746zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zetx-pinctrl.dtsi
@@ -1363,61 +1363,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
@@ -1363,61 +1363,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
@@ -1619,71 +1619,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
@@ -1066,51 +1066,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
@@ -1363,61 +1363,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
@@ -1619,71 +1619,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f756igkx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igkx-pinctrl.dtsi
@@ -1619,71 +1619,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f756igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igtx-pinctrl.dtsi
@@ -1619,71 +1619,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f756nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756nghx-pinctrl.dtsi
@@ -1619,71 +1619,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f756vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vghx-pinctrl.dtsi
@@ -1066,51 +1066,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
@@ -1066,51 +1066,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
@@ -1363,61 +1363,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
@@ -1363,61 +1363,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
@@ -1848,91 +1848,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
@@ -1848,91 +1848,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
@@ -1848,91 +1848,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
@@ -1848,91 +1848,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
@@ -1240,66 +1240,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
@@ -1240,66 +1240,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
@@ -1587,81 +1587,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
@@ -1848,91 +1848,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
@@ -1848,91 +1848,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
@@ -1848,91 +1848,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
@@ -1848,91 +1848,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f767vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vghx-pinctrl.dtsi
@@ -1240,66 +1240,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
@@ -1240,66 +1240,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f767vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vihx-pinctrl.dtsi
@@ -1240,66 +1240,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f767vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vitx-pinctrl.dtsi
@@ -1240,66 +1240,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
@@ -1587,81 +1587,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f767zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zitx-pinctrl.dtsi
@@ -1587,81 +1587,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
@@ -1480,81 +1480,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
@@ -1480,81 +1480,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
@@ -1848,91 +1848,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f769igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769igtx-pinctrl.dtsi
@@ -1762,91 +1762,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f769iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769iitx-pinctrl.dtsi
@@ -1762,91 +1762,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f769nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nghx-pinctrl.dtsi
@@ -1848,91 +1848,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f769nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nihx-pinctrl.dtsi
@@ -1848,91 +1848,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f777bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777bitx-pinctrl.dtsi
@@ -1848,91 +1848,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f777iikx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iikx-pinctrl.dtsi
@@ -1848,91 +1848,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f777iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iitx-pinctrl.dtsi
@@ -1848,91 +1848,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f777nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777nihx-pinctrl.dtsi
@@ -1848,91 +1848,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f777vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vihx-pinctrl.dtsi
@@ -1240,66 +1240,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f777vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vitx-pinctrl.dtsi
@@ -1240,66 +1240,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f777zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777zitx-pinctrl.dtsi
@@ -1587,81 +1587,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
@@ -1480,81 +1480,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
@@ -1480,81 +1480,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f779bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779bitx-pinctrl.dtsi
@@ -1848,91 +1848,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f779iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779iitx-pinctrl.dtsi
@@ -1762,91 +1762,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/f7/stm32f779nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779nihx-pinctrl.dtsi
@@ -1848,91 +1848,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g030c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030c(6-8)tx-pinctrl.dtsi
@@ -358,41 +358,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g030f6px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030f6px-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g030j6mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030j6mx-pinctrl.dtsi
@@ -205,16 +205,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g030k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030k(6-8)tx-pinctrl.dtsi
@@ -304,26 +304,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g031c(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031c(4-6-8)tx-pinctrl.dtsi
@@ -358,41 +358,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g031c(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031c(4-6-8)ux-pinctrl.dtsi
@@ -362,41 +362,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g031f(4-6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031f(4-6-8)px-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g031g(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031g(4-6-8)ux-pinctrl.dtsi
@@ -262,26 +262,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g031j(4-6)mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031j(4-6)mx-pinctrl.dtsi
@@ -205,16 +205,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g031k(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031k(4-6-8)tx-pinctrl.dtsi
@@ -304,26 +304,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g031k(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031k(4-6-8)ux-pinctrl.dtsi
@@ -304,26 +304,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g031y8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031y8yx-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g041c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041c(6-8)tx-pinctrl.dtsi
@@ -358,41 +358,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g041c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041c(6-8)ux-pinctrl.dtsi
@@ -362,41 +362,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g041f(6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041f(6-8)px-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g041g(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041g(6-8)ux-pinctrl.dtsi
@@ -262,26 +262,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g041j6mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041j6mx-pinctrl.dtsi
@@ -205,16 +205,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g041k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041k(6-8)tx-pinctrl.dtsi
@@ -304,26 +304,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g041k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041k(6-8)ux-pinctrl.dtsi
@@ -304,26 +304,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g041y8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041y8yx-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g050c6tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050c6tx-pinctrl.dtsi
@@ -370,41 +370,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g050c8tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050c8tx-pinctrl.dtsi
@@ -370,41 +370,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g050f6px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050f6px-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g050k6tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050k6tx-pinctrl.dtsi
@@ -304,26 +304,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g050k8tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050k8tx-pinctrl.dtsi
@@ -304,26 +304,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g051c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051c(6-8)tx-pinctrl.dtsi
@@ -380,41 +380,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g051c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051c(6-8)ux-pinctrl.dtsi
@@ -380,41 +380,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g051f(6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051f(6-8)px-pinctrl.dtsi
@@ -292,26 +292,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g051f8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051f8yx-pinctrl.dtsi
@@ -292,26 +292,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g051g(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051g(6-8)ux-pinctrl.dtsi
@@ -272,26 +272,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g051k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051k(6-8)tx-pinctrl.dtsi
@@ -314,26 +314,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g051k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051k(6-8)ux-pinctrl.dtsi
@@ -314,26 +314,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g061c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061c(6-8)tx-pinctrl.dtsi
@@ -380,41 +380,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g061c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061c(6-8)ux-pinctrl.dtsi
@@ -380,41 +380,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g061f(6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061f(6-8)px-pinctrl.dtsi
@@ -292,26 +292,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g061f8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061f8yx-pinctrl.dtsi
@@ -292,26 +292,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g061g(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061g(6-8)ux-pinctrl.dtsi
@@ -272,26 +272,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g061k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061k(6-8)tx-pinctrl.dtsi
@@ -314,26 +314,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g061k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061k(6-8)ux-pinctrl.dtsi
@@ -314,26 +314,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g070cbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070cbtx-pinctrl.dtsi
@@ -350,41 +350,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g070kbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070kbtx-pinctrl.dtsi
@@ -284,26 +284,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g070rbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070rbtx-pinctrl.dtsi
@@ -401,46 +401,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g071c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071c(6-8-b)tx-pinctrl.dtsi
@@ -360,41 +360,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g071c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071c(6-8-b)ux-pinctrl.dtsi
@@ -360,41 +360,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g071ebyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071ebyx-pinctrl.dtsi
@@ -242,21 +242,25 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g071g(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071g(6-8-b)ux-pinctrl.dtsi
@@ -252,26 +252,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g071g(8-b)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071g(8-b)uxn-pinctrl.dtsi
@@ -235,26 +235,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g071k(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(6-8-b)tx-pinctrl.dtsi
@@ -294,26 +294,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g071k(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(6-8-b)ux-pinctrl.dtsi
@@ -294,26 +294,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g071k(8-b)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(8-b)txn-pinctrl.dtsi
@@ -272,26 +272,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g071k(8-b)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(8-b)uxn-pinctrl.dtsi
@@ -272,26 +272,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi
@@ -411,46 +411,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g071rbix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071rbix-pinctrl.dtsi
@@ -411,46 +411,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g081cbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081cbtx-pinctrl.dtsi
@@ -360,41 +360,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g081cbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081cbux-pinctrl.dtsi
@@ -360,41 +360,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g081ebyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081ebyx-pinctrl.dtsi
@@ -242,21 +242,25 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g081gbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081gbux-pinctrl.dtsi
@@ -252,26 +252,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g081gbuxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081gbuxn-pinctrl.dtsi
@@ -235,26 +235,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g081kbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbtx-pinctrl.dtsi
@@ -294,26 +294,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g081kbtxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbtxn-pinctrl.dtsi
@@ -272,26 +272,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g081kbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbux-pinctrl.dtsi
@@ -294,26 +294,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g081kbuxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbuxn-pinctrl.dtsi
@@ -272,26 +272,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g081rbix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081rbix-pinctrl.dtsi
@@ -411,46 +411,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g081rbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081rbtx-pinctrl.dtsi
@@ -411,46 +411,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b0cetx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0cetx-pinctrl.dtsi
@@ -507,46 +507,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b0ketx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0ketx-pinctrl.dtsi
@@ -410,31 +410,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b0retx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0retx-pinctrl.dtsi
@@ -588,56 +588,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b0vetx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0vetx-pinctrl.dtsi
@@ -616,61 +616,73 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)tx-pinctrl.dtsi
@@ -569,46 +569,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1c(b-c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)txn-pinctrl.dtsi
@@ -569,46 +569,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)ux-pinctrl.dtsi
@@ -569,46 +569,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1c(b-c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)uxn-pinctrl.dtsi
@@ -569,46 +569,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(c-e)tx-pinctrl.dtsi
@@ -569,46 +569,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(c-e)ux-pinctrl.dtsi
@@ -569,46 +569,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1k(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)tx-pinctrl.dtsi
@@ -456,31 +456,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1k(b-c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)txn-pinctrl.dtsi
@@ -407,26 +407,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1k(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)ux-pinctrl.dtsi
@@ -456,31 +456,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1k(b-c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)uxn-pinctrl.dtsi
@@ -407,26 +407,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1k(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(c-e)tx-pinctrl.dtsi
@@ -456,31 +456,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1k(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(c-e)txn-pinctrl.dtsi
@@ -407,26 +407,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(c-e)ux-pinctrl.dtsi
@@ -456,31 +456,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1k(c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(c-e)uxn-pinctrl.dtsi
@@ -407,26 +407,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1m(b-c-e)tx-pinctrl.dtsi
@@ -682,56 +682,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1m(c-e)tx-pinctrl.dtsi
@@ -682,56 +682,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1neyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1neyx-pinctrl.dtsi
@@ -585,46 +585,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1r(b-c-e)ixn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(b-c-e)ixn-pinctrl.dtsi
@@ -652,51 +652,61 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(b-c-e)tx-pinctrl.dtsi
@@ -666,56 +666,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1r(b-c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(b-c-e)txn-pinctrl.dtsi
@@ -652,51 +652,61 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(c-e)ix-pinctrl.dtsi
@@ -666,56 +666,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(c-e)tx-pinctrl.dtsi
@@ -666,56 +666,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1v(b-c-e)ix-pinctrl.dtsi
@@ -710,61 +710,73 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1v(b-c-e)tx-pinctrl.dtsi
@@ -710,61 +710,73 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1v(c-e)ix-pinctrl.dtsi
@@ -710,61 +710,73 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0b1v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1v(c-e)tx-pinctrl.dtsi
@@ -710,61 +710,73 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0c1c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)tx-pinctrl.dtsi
@@ -569,46 +569,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0c1c(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)txn-pinctrl.dtsi
@@ -569,46 +569,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0c1c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)ux-pinctrl.dtsi
@@ -569,46 +569,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0c1c(c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)uxn-pinctrl.dtsi
@@ -569,46 +569,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0c1k(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)tx-pinctrl.dtsi
@@ -456,31 +456,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0c1k(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)txn-pinctrl.dtsi
@@ -407,26 +407,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0c1k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)ux-pinctrl.dtsi
@@ -456,31 +456,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0c1k(c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)uxn-pinctrl.dtsi
@@ -407,26 +407,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0c1m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1m(c-e)tx-pinctrl.dtsi
@@ -682,56 +682,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0c1neyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1neyx-pinctrl.dtsi
@@ -585,46 +585,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0c1r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)ix-pinctrl.dtsi
@@ -666,56 +666,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0c1r(c-e)ixn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)ixn-pinctrl.dtsi
@@ -652,51 +652,61 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0c1r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)tx-pinctrl.dtsi
@@ -666,56 +666,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0c1r(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)txn-pinctrl.dtsi
@@ -652,51 +652,61 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0c1v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1v(c-e)ix-pinctrl.dtsi
@@ -710,61 +710,73 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g0/stm32g0c1v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1v(c-e)tx-pinctrl.dtsi
@@ -710,61 +710,73 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pd8: spi1_sck_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa0: spi2_sck_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb8: spi2_sck_pb8 {
 				pinmux = <STM32_PINMUX('B', 8, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF4)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g431c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431c(6-8-b)tx-pinctrl.dtsi
@@ -331,26 +331,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g431c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431c(6-8-b)ux-pinctrl.dtsi
@@ -357,31 +357,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g431cbyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431cbyx-pinctrl.dtsi
@@ -352,26 +352,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g431k(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431k(6-8-b)tx-pinctrl.dtsi
@@ -265,21 +265,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g431k(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431k(6-8-b)ux-pinctrl.dtsi
@@ -265,21 +265,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g431m(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431m(6-8-b)tx-pinctrl.dtsi
@@ -422,31 +422,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g431r(6-8-b)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431r(6-8-b)ix-pinctrl.dtsi
@@ -414,31 +414,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi
@@ -414,31 +414,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
@@ -427,41 +427,49 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g441cbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbtx-pinctrl.dtsi
@@ -331,26 +331,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g441cbux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbux-pinctrl.dtsi
@@ -357,31 +357,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g441cbyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbyx-pinctrl.dtsi
@@ -352,26 +352,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g441kbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441kbtx-pinctrl.dtsi
@@ -265,21 +265,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g441kbux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441kbux-pinctrl.dtsi
@@ -265,21 +265,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g441mbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441mbtx-pinctrl.dtsi
@@ -422,31 +422,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g441rbix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441rbix-pinctrl.dtsi
@@ -414,31 +414,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g441rbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441rbtx-pinctrl.dtsi
@@ -414,31 +414,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
@@ -427,41 +427,49 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
@@ -371,26 +371,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
@@ -403,31 +403,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
@@ -521,36 +521,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g471meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471meyx-pinctrl.dtsi
@@ -525,36 +525,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
@@ -631,61 +631,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
@@ -466,31 +466,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
@@ -562,51 +562,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
@@ -562,51 +562,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
@@ -562,51 +562,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
@@ -411,26 +411,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
@@ -443,31 +443,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
@@ -625,36 +625,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g473meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473meyx-pinctrl.dtsi
@@ -637,36 +637,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g473p(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473p(b-c-e)ix-pinctrl.dtsi
@@ -1058,56 +1058,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
@@ -1111,61 +1111,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
@@ -506,31 +506,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
@@ -916,51 +916,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g473v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)ix-pinctrl.dtsi
@@ -916,51 +916,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
@@ -916,51 +916,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
@@ -493,26 +493,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
@@ -537,31 +537,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
@@ -739,36 +739,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g474meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474meyx-pinctrl.dtsi
@@ -751,36 +751,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g474p(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474p(b-c-e)ix-pinctrl.dtsi
@@ -1172,56 +1172,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
@@ -1225,61 +1225,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
@@ -620,31 +620,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
@@ -1030,51 +1030,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g474v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)ix-pinctrl.dtsi
@@ -1030,51 +1030,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
@@ -1030,51 +1030,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g483cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483cetx-pinctrl.dtsi
@@ -411,26 +411,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g483ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483ceux-pinctrl.dtsi
@@ -443,31 +443,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g483metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483metx-pinctrl.dtsi
@@ -625,36 +625,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g483meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483meyx-pinctrl.dtsi
@@ -637,36 +637,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g483peix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483peix-pinctrl.dtsi
@@ -1058,56 +1058,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g483qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483qetx-pinctrl.dtsi
@@ -1111,61 +1111,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g483retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483retx-pinctrl.dtsi
@@ -506,31 +506,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g483vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vehx-pinctrl.dtsi
@@ -916,51 +916,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g483veix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483veix-pinctrl.dtsi
@@ -916,51 +916,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g483vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vetx-pinctrl.dtsi
@@ -916,51 +916,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g484cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484cetx-pinctrl.dtsi
@@ -493,26 +493,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g484ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484ceux-pinctrl.dtsi
@@ -537,31 +537,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g484metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484metx-pinctrl.dtsi
@@ -739,36 +739,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g484meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484meyx-pinctrl.dtsi
@@ -751,36 +751,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g484peix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484peix-pinctrl.dtsi
@@ -1172,56 +1172,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g484qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484qetx-pinctrl.dtsi
@@ -1225,61 +1225,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g484retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484retx-pinctrl.dtsi
@@ -620,31 +620,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g484vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vehx-pinctrl.dtsi
@@ -1030,51 +1030,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g484veix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484veix-pinctrl.dtsi
@@ -1030,51 +1030,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g484vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vetx-pinctrl.dtsi
@@ -1030,51 +1030,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g491c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491c(c-e)tx-pinctrl.dtsi
@@ -359,26 +359,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g491c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491c(c-e)ux-pinctrl.dtsi
@@ -385,31 +385,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g491k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491k(c-e)ux-pinctrl.dtsi
@@ -277,21 +277,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g491m(c-e)sx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491m(c-e)sx-pinctrl.dtsi
@@ -482,31 +482,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g491m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491m(c-e)tx-pinctrl.dtsi
@@ -482,31 +482,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g491r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491r(c-e)ix-pinctrl.dtsi
@@ -442,31 +442,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g491r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491r(c-e)tx-pinctrl.dtsi
@@ -442,31 +442,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g491reyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491reyx-pinctrl.dtsi
@@ -442,31 +442,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g491v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491v(c-e)tx-pinctrl.dtsi
@@ -503,41 +503,49 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g4a1cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1cetx-pinctrl.dtsi
@@ -359,26 +359,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g4a1ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1ceux-pinctrl.dtsi
@@ -385,31 +385,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g4a1keux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1keux-pinctrl.dtsi
@@ -277,21 +277,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g4a1mesx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1mesx-pinctrl.dtsi
@@ -482,31 +482,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g4a1metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1metx-pinctrl.dtsi
@@ -482,31 +482,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g4a1reix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1reix-pinctrl.dtsi
@@ -442,31 +442,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g4a1retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1retx-pinctrl.dtsi
@@ -442,31 +442,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g4a1reyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1reyx-pinctrl.dtsi
@@ -442,31 +442,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32g4a1vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1vetx-pinctrl.dtsi
@@ -503,41 +503,49 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf9: spi2_sck_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf10: spi2_sck_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/g4/stm32gbk1cbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32gbk1cbtx-pinctrl.dtsi
@@ -367,26 +367,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pf1: spi2_sck_pf1 {
 				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h723vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vehx-pinctrl.dtsi
@@ -1280,71 +1280,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h723vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vetx-pinctrl.dtsi
@@ -1280,71 +1280,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h723vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vghx-pinctrl.dtsi
@@ -1280,71 +1280,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
@@ -1280,71 +1280,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h723zeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zeix-pinctrl.dtsi
@@ -1712,86 +1712,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h723zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zetx-pinctrl.dtsi
@@ -1684,86 +1684,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h723zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgix-pinctrl.dtsi
@@ -1712,86 +1712,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
@@ -1684,86 +1684,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h725aeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725aeix-pinctrl.dtsi
@@ -1899,86 +1899,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h725agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725agix-pinctrl.dtsi
@@ -1899,86 +1899,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h725iekx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725iekx-pinctrl.dtsi
@@ -1995,91 +1995,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h725ietx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725ietx-pinctrl.dtsi
@@ -1699,91 +1699,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h725igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igkx-pinctrl.dtsi
@@ -1995,91 +1995,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h725igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igtx-pinctrl.dtsi
@@ -1699,91 +1699,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h725revx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725revx-pinctrl.dtsi
@@ -663,56 +663,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
@@ -663,56 +663,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h725vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vehx-pinctrl.dtsi
@@ -1235,66 +1235,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h725vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vetx-pinctrl.dtsi
@@ -1162,66 +1162,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h725vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vghx-pinctrl.dtsi
@@ -1235,66 +1235,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
@@ -1162,66 +1162,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
@@ -1104,61 +1104,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h725zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zetx-pinctrl.dtsi
@@ -1542,86 +1542,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
@@ -1542,86 +1542,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h730abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730abixq-pinctrl.dtsi
@@ -1832,86 +1832,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
@@ -1928,91 +1928,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
@@ -1663,91 +1663,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
@@ -1244,71 +1244,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
@@ -1244,71 +1244,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h730zbix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbix-pinctrl.dtsi
@@ -1712,86 +1712,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
@@ -1648,86 +1648,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h733vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vghx-pinctrl.dtsi
@@ -1280,71 +1280,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
@@ -1280,71 +1280,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h733zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgix-pinctrl.dtsi
@@ -1712,86 +1712,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
@@ -1684,86 +1684,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h735agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735agix-pinctrl.dtsi
@@ -1899,86 +1899,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h735igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igkx-pinctrl.dtsi
@@ -1995,91 +1995,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h735igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igtx-pinctrl.dtsi
@@ -1699,91 +1699,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
@@ -663,56 +663,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h735vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vghx-pinctrl.dtsi
@@ -1235,66 +1235,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
@@ -1162,66 +1162,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
@@ -1104,61 +1104,73 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
@@ -1542,86 +1542,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -1772,86 +1772,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -1897,96 +1897,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -1846,91 +1846,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -1846,91 +1846,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -1217,66 +1217,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -1217,66 +1217,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -1961,96 +1961,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -1599,81 +1599,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -1772,86 +1772,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -1897,96 +1897,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -1897,96 +1897,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -1882,91 +1882,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -1882,91 +1882,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -1882,91 +1882,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -1882,91 +1882,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -1217,66 +1217,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -1217,66 +1217,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -1217,66 +1217,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -1961,96 +1961,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -1961,96 +1961,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -1599,81 +1599,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -1599,81 +1599,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -1897,96 +1897,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -1897,96 +1897,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -1853,86 +1853,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -1614,86 +1614,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -1853,86 +1853,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -1614,86 +1614,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -1961,96 +1961,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -1961,96 +1961,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -1469,81 +1469,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -1469,81 +1469,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -1599,81 +1599,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -1882,91 +1882,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -1882,91 +1882,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -1599,81 +1599,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -1599,81 +1599,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -1961,96 +1961,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -1961,96 +1961,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -1405,66 +1405,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -1882,91 +1882,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -1846,91 +1846,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -1217,66 +1217,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -1961,96 +1961,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -1599,81 +1599,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -1772,86 +1772,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -1897,96 +1897,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -1882,91 +1882,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -1882,91 +1882,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -1217,66 +1217,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -1217,66 +1217,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -1961,96 +1961,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -1599,81 +1599,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -1897,96 +1897,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -1853,86 +1853,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -1614,86 +1614,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -1961,96 +1961,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -1469,81 +1469,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -1599,81 +1599,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -1882,91 +1882,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -1599,81 +1599,97 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -1961,96 +1961,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -1405,66 +1405,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -1461,86 +1461,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -1539,96 +1539,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -1531,91 +1531,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -1539,96 +1539,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -1334,91 +1334,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -1634,101 +1634,121 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -1554,101 +1554,121 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
@@ -1127,76 +1127,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
@@ -666,56 +666,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
@@ -1016,71 +1016,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
@@ -971,66 +971,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
@@ -1016,71 +1016,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
@@ -904,66 +904,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -1319,86 +1319,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
@@ -1205,86 +1205,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -1461,86 +1461,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -1531,91 +1531,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -1539,96 +1539,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
@@ -666,56 +666,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
@@ -1016,71 +1016,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -1319,86 +1319,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -1461,86 +1461,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -1539,96 +1539,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -1531,91 +1531,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -1539,96 +1539,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -1334,91 +1334,109 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -1634,101 +1634,121 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -1554,101 +1554,121 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
@@ -1127,76 +1127,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
@@ -666,56 +666,67 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
@@ -1016,71 +1016,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
@@ -971,66 +971,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
@@ -1016,71 +1016,85 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
@@ -904,66 +904,79 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -1319,86 +1319,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
@@ -1205,86 +1205,103 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg11: spi1_sck_pg11 {
 				pinmux = <STM32_PINMUX('G', 11, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa12: spi2_sck_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pc12: spi6_sck_pc12 {
 				pinmux = <STM32_PINMUX('C', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l010c6tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010c6tx-pinctrl.dtsi
@@ -167,16 +167,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb13: spi1_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l010f4px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010f4px-pinctrl.dtsi
@@ -111,11 +111,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa13: spi1_sck_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l010k4tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010k4tx-pinctrl.dtsi
@@ -157,16 +157,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa13: spi1_sck_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l010k8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010k8tx-pinctrl.dtsi
@@ -118,11 +118,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l010r8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010r8tx-pinctrl.dtsi
@@ -154,11 +154,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l010rbtx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010rbtx-pinctrl.dtsi
@@ -166,11 +166,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l011d(3-4)px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011d(3-4)px-pinctrl.dtsi
@@ -81,6 +81,7 @@
 
 			spi1_sck_pa13: spi1_sck_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l011e(3-4)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011e(3-4)yx-pinctrl.dtsi
@@ -132,16 +132,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa13: spi1_sck_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l011f(3-4)px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011f(3-4)px-pinctrl.dtsi
@@ -111,11 +111,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa13: spi1_sck_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l011f(3-4)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011f(3-4)ux-pinctrl.dtsi
@@ -115,11 +115,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa13: spi1_sck_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l011g(3-4)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011g(3-4)ux-pinctrl.dtsi
@@ -147,16 +147,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa13: spi1_sck_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l011k(3-4)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011k(3-4)tx-pinctrl.dtsi
@@ -157,16 +157,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa13: spi1_sck_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l011k(3-4)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011k(3-4)ux-pinctrl.dtsi
@@ -168,16 +168,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa13: spi1_sck_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l021d4px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021d4px-pinctrl.dtsi
@@ -81,6 +81,7 @@
 
 			spi1_sck_pa13: spi1_sck_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l021f4px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021f4px-pinctrl.dtsi
@@ -111,11 +111,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa13: spi1_sck_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l021f4ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021f4ux-pinctrl.dtsi
@@ -115,11 +115,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa13: spi1_sck_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l021g4ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021g4ux-pinctrl.dtsi
@@ -147,16 +147,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa13: spi1_sck_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l021k4tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021k4tx-pinctrl.dtsi
@@ -157,16 +157,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa13: spi1_sck_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l021k4ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021k4ux-pinctrl.dtsi
@@ -168,16 +168,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa13: spi1_sck_pa13 {
 				pinmux = <STM32_PINMUX('A', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l031c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031c(4-6)tx-pinctrl.dtsi
@@ -167,16 +167,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb13: spi1_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l031c(4-6)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031c(4-6)ux-pinctrl.dtsi
@@ -167,16 +167,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb13: spi1_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l031e(4-6)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031e(4-6)yx-pinctrl.dtsi
@@ -115,11 +115,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l031f(4-6)px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031f(4-6)px-pinctrl.dtsi
@@ -94,6 +94,7 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l031g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031g(4-6)ux-pinctrl.dtsi
@@ -120,11 +120,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l031g6uxs-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031g6uxs-pinctrl.dtsi
@@ -130,11 +130,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l031k(4-6)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031k(4-6)tx-pinctrl.dtsi
@@ -140,11 +140,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l031k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031k(4-6)ux-pinctrl.dtsi
@@ -146,11 +146,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l041c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041c(4-6)tx-pinctrl.dtsi
@@ -167,16 +167,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb13: spi1_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l041c6ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041c6ux-pinctrl.dtsi
@@ -167,16 +167,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb13: spi1_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l041e6yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041e6yx-pinctrl.dtsi
@@ -115,11 +115,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l041f6px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041f6px-pinctrl.dtsi
@@ -94,6 +94,7 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l041g6ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041g6ux-pinctrl.dtsi
@@ -120,11 +120,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l041g6uxs-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041g6uxs-pinctrl.dtsi
@@ -130,11 +130,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l041k6tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041k6tx-pinctrl.dtsi
@@ -140,11 +140,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l041k6ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041k6ux-pinctrl.dtsi
@@ -146,11 +146,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l051c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051c(6-8)tx-pinctrl.dtsi
@@ -197,21 +197,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l051c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051c(6-8)ux-pinctrl.dtsi
@@ -197,21 +197,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l051k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051k(6-8)tx-pinctrl.dtsi
@@ -118,11 +118,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l051k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051k(6-8)ux-pinctrl.dtsi
@@ -124,11 +124,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l051r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051r(6-8)hx-pinctrl.dtsi
@@ -222,21 +222,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l051r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051r(6-8)tx-pinctrl.dtsi
@@ -235,21 +235,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l051t(6-8)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051t(6-8)yx-pinctrl.dtsi
@@ -136,11 +136,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l052c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052c(6-8)tx-pinctrl.dtsi
@@ -203,21 +203,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l052c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052c(6-8)ux-pinctrl.dtsi
@@ -203,21 +203,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l052k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052k(6-8)tx-pinctrl.dtsi
@@ -124,11 +124,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l052k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052k(6-8)ux-pinctrl.dtsi
@@ -130,11 +130,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l052r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052r(6-8)hx-pinctrl.dtsi
@@ -228,21 +228,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l052r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052r(6-8)tx-pinctrl.dtsi
@@ -241,21 +241,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l052t(6-8)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052t(6-8)yx-pinctrl.dtsi
@@ -142,11 +142,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l052t8fx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052t8fx-pinctrl.dtsi
@@ -142,11 +142,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l053c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053c(6-8)tx-pinctrl.dtsi
@@ -203,21 +203,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l053c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053c(6-8)ux-pinctrl.dtsi
@@ -203,21 +203,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l053r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053r(6-8)hx-pinctrl.dtsi
@@ -228,21 +228,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l053r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053r(6-8)tx-pinctrl.dtsi
@@ -241,21 +241,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l062c8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l062c8ux-pinctrl.dtsi
@@ -203,21 +203,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l062k8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l062k8tx-pinctrl.dtsi
@@ -124,11 +124,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l062k8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l062k8ux-pinctrl.dtsi
@@ -130,11 +130,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l063c8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063c8tx-pinctrl.dtsi
@@ -203,21 +203,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l063c8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063c8ux-pinctrl.dtsi
@@ -203,21 +203,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l063r8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063r8tx-pinctrl.dtsi
@@ -241,21 +241,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l071c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c(b-z)tx-pinctrl.dtsi
@@ -221,21 +221,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l071c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c(b-z)ux-pinctrl.dtsi
@@ -221,21 +221,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l071c(b-z)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c(b-z)yx-pinctrl.dtsi
@@ -250,21 +250,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l071c8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c8tx-pinctrl.dtsi
@@ -221,21 +221,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l071c8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c8ux-pinctrl.dtsi
@@ -221,21 +221,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l071k(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071k(b-z)tx-pinctrl.dtsi
@@ -142,11 +142,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l071k(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071k(b-z)ux-pinctrl.dtsi
@@ -137,6 +137,7 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l071k8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071k8ux-pinctrl.dtsi
@@ -137,6 +137,7 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l071r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071r(b-z)hx-pinctrl.dtsi
@@ -264,21 +264,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l071r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071r(b-z)tx-pinctrl.dtsi
@@ -277,21 +277,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l071v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v(b-z)ix-pinctrl.dtsi
@@ -320,31 +320,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l071v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v(b-z)tx-pinctrl.dtsi
@@ -320,31 +320,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l071v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v8ix-pinctrl.dtsi
@@ -320,31 +320,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l071v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v8tx-pinctrl.dtsi
@@ -320,31 +320,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l072c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)tx-pinctrl.dtsi
@@ -231,21 +231,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l072c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)ux-pinctrl.dtsi
@@ -231,21 +231,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l072c(b-z)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)yx-pinctrl.dtsi
@@ -260,21 +260,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l072czex-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072czex-pinctrl.dtsi
@@ -260,21 +260,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l072k(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072k(b-z)tx-pinctrl.dtsi
@@ -152,11 +152,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l072k(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072k(b-z)ux-pinctrl.dtsi
@@ -147,6 +147,7 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l072r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)hx-pinctrl.dtsi
@@ -274,21 +274,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l072r(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)ix-pinctrl.dtsi
@@ -274,21 +274,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l072r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)tx-pinctrl.dtsi
@@ -287,21 +287,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l072v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v(b-z)ix-pinctrl.dtsi
@@ -330,31 +330,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l072v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v(b-z)tx-pinctrl.dtsi
@@ -330,31 +330,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l072v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v8ix-pinctrl.dtsi
@@ -330,31 +330,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l072v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v8tx-pinctrl.dtsi
@@ -330,31 +330,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l073c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073c(b-z)tx-pinctrl.dtsi
@@ -231,21 +231,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l073c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073c(b-z)ux-pinctrl.dtsi
@@ -231,21 +231,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l073czyx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073czyx-pinctrl.dtsi
@@ -260,21 +260,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l073r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073r(b-z)hx-pinctrl.dtsi
@@ -274,21 +274,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l073r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073r(b-z)tx-pinctrl.dtsi
@@ -287,21 +287,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l073rzix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073rzix-pinctrl.dtsi
@@ -274,21 +274,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l073v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v(b-z)ix-pinctrl.dtsi
@@ -330,31 +330,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l073v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v(b-z)tx-pinctrl.dtsi
@@ -330,31 +330,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l073v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v8ix-pinctrl.dtsi
@@ -330,31 +330,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l073v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v8tx-pinctrl.dtsi
@@ -330,31 +330,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l081c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081c(b-z)tx-pinctrl.dtsi
@@ -221,21 +221,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l081czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081czux-pinctrl.dtsi
@@ -221,21 +221,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l081kztx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081kztx-pinctrl.dtsi
@@ -142,11 +142,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l081kzux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081kzux-pinctrl.dtsi
@@ -137,6 +137,7 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l082czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082czux-pinctrl.dtsi
@@ -231,21 +231,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l082czyx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082czyx-pinctrl.dtsi
@@ -260,21 +260,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l082k(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082k(b-z)tx-pinctrl.dtsi
@@ -152,11 +152,13 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l082k(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082k(b-z)ux-pinctrl.dtsi
@@ -147,6 +147,7 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l083c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083c(b-z)tx-pinctrl.dtsi
@@ -231,21 +231,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l083czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083czux-pinctrl.dtsi
@@ -231,21 +231,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l083r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083r(b-z)hx-pinctrl.dtsi
@@ -274,21 +274,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l083r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083r(b-z)tx-pinctrl.dtsi
@@ -287,21 +287,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l083v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v(b-z)ix-pinctrl.dtsi
@@ -330,31 +330,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l083v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v(b-z)tx-pinctrl.dtsi
@@ -330,31 +330,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l083v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v8ix-pinctrl.dtsi
@@ -330,31 +330,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l0/stm32l083v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v8tx-pinctrl.dtsi
@@ -330,31 +330,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF2)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF0)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF1)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l100c6ux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100c6ux-pinctrl.dtsi
@@ -183,16 +183,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l100c6uxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100c6uxa-pinctrl.dtsi
@@ -183,16 +183,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l100r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100r(8-b)tx-pinctrl.dtsi
@@ -207,16 +207,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l100r(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100r(8-b)txa-pinctrl.dtsi
@@ -207,16 +207,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l100rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100rctx-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)tx-pinctrl.dtsi
@@ -183,16 +183,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151c(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)txa-pinctrl.dtsi
@@ -183,16 +183,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)ux-pinctrl.dtsi
@@ -183,16 +183,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151c(6-8-b)uxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)uxa-pinctrl.dtsi
@@ -183,16 +183,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151cctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151cctx-pinctrl.dtsi
@@ -239,21 +239,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151ccux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151ccux-pinctrl.dtsi
@@ -239,21 +239,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qchx-pinctrl.dtsi
@@ -357,36 +357,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qdhx-pinctrl.dtsi
@@ -357,36 +357,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151qehx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qehx-pinctrl.dtsi
@@ -357,36 +357,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151r(6-8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)hx-pinctrl.dtsi
@@ -203,16 +203,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151r(6-8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)hxa-pinctrl.dtsi
@@ -203,16 +203,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)tx-pinctrl.dtsi
@@ -207,16 +207,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151r(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)txa-pinctrl.dtsi
@@ -207,16 +207,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rctx-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rctxa-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151rcyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rcyx-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rdtx-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rdyx-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151retx-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151ucyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151ucyx-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)hx-pinctrl.dtsi
@@ -253,26 +253,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151v(8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)hxa-pinctrl.dtsi
@@ -253,26 +253,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)tx-pinctrl.dtsi
@@ -253,26 +253,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151v(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)txa-pinctrl.dtsi
@@ -253,26 +253,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vchx-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vctx-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vctxa-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdtx-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151vdtxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdtxx-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151vdyxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdyxx-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vetx-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151veyx-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zctx-pinctrl.dtsi
@@ -361,36 +361,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zdtx-pinctrl.dtsi
@@ -361,36 +361,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l151zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zetx-pinctrl.dtsi
@@ -361,36 +361,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)tx-pinctrl.dtsi
@@ -183,16 +183,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152c(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)txa-pinctrl.dtsi
@@ -183,16 +183,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)ux-pinctrl.dtsi
@@ -183,16 +183,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152c(6-8-b)uxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)uxa-pinctrl.dtsi
@@ -183,16 +183,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152cctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152cctx-pinctrl.dtsi
@@ -239,21 +239,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152ccux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152ccux-pinctrl.dtsi
@@ -239,21 +239,25 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qchx-pinctrl.dtsi
@@ -357,36 +357,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qdhx-pinctrl.dtsi
@@ -357,36 +357,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152qehx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qehx-pinctrl.dtsi
@@ -357,36 +357,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152r(6-8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)hx-pinctrl.dtsi
@@ -203,16 +203,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152r(6-8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)hxa-pinctrl.dtsi
@@ -203,16 +203,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)tx-pinctrl.dtsi
@@ -207,16 +207,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152r(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)txa-pinctrl.dtsi
@@ -207,16 +207,19 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rctx-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rctxa-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rdtx-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rdyx-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152retx-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152ucyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152ucyx-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)hx-pinctrl.dtsi
@@ -253,26 +253,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152v(8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)hxa-pinctrl.dtsi
@@ -253,26 +253,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)tx-pinctrl.dtsi
@@ -253,26 +253,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152v(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)txa-pinctrl.dtsi
@@ -253,26 +253,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vchx-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vctx-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vctxa-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vdtx-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152vdtxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vdtxx-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vetx-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152veyx-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zctx-pinctrl.dtsi
@@ -361,36 +361,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zdtx-pinctrl.dtsi
@@ -361,36 +361,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l152zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zetx-pinctrl.dtsi
@@ -361,36 +361,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l162qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162qchx-pinctrl.dtsi
@@ -357,36 +357,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l162qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162qdhx-pinctrl.dtsi
@@ -357,36 +357,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l162rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rctx-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l162rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rctxa-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l162rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rdtx-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l162rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rdyx-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l162retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162retx-pinctrl.dtsi
@@ -282,26 +282,31 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l162vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vchx-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l162vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vctx-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l162vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vctxa-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l162vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vdtx-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l162vdyxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vdyxx-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l162vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vetx-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l162veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162veyx-pinctrl.dtsi
@@ -341,36 +341,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l162zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zctx-pinctrl.dtsi
@@ -361,36 +361,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l162zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zdtx-pinctrl.dtsi
@@ -361,36 +361,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l1/stm32l162zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zetx-pinctrl.dtsi
@@ -361,36 +361,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l412c8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412c8tx-pinctrl.dtsi
@@ -277,26 +277,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l412c8ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412c8ux-pinctrl.dtsi
@@ -277,26 +277,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l412cbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbtx-pinctrl.dtsi
@@ -277,26 +277,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l412cbtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbtxp-pinctrl.dtsi
@@ -260,26 +260,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l412cbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbux-pinctrl.dtsi
@@ -277,26 +277,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l412cbuxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbuxp-pinctrl.dtsi
@@ -260,26 +260,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l412k8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412k8tx-pinctrl.dtsi
@@ -211,16 +211,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l412k8ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412k8ux-pinctrl.dtsi
@@ -211,16 +211,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l412kbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412kbtx-pinctrl.dtsi
@@ -211,16 +211,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l412kbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412kbux-pinctrl.dtsi
@@ -211,16 +211,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l412r8ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412r8ix-pinctrl.dtsi
@@ -347,26 +347,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l412r8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412r8tx-pinctrl.dtsi
@@ -347,26 +347,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l412rbix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbix-pinctrl.dtsi
@@ -347,26 +347,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l412rbixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbixp-pinctrl.dtsi
@@ -339,26 +339,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l412rbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbtx-pinctrl.dtsi
@@ -347,26 +347,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l412rbtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbtxp-pinctrl.dtsi
@@ -339,26 +339,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l412t8yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412t8yx-pinctrl.dtsi
@@ -222,16 +222,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l412tbyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412tbyx-pinctrl.dtsi
@@ -222,16 +222,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l412tbyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412tbyxp-pinctrl.dtsi
@@ -216,16 +216,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l422cbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422cbtx-pinctrl.dtsi
@@ -277,26 +277,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l422cbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422cbux-pinctrl.dtsi
@@ -277,26 +277,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l422kbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422kbtx-pinctrl.dtsi
@@ -211,16 +211,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l422kbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422kbux-pinctrl.dtsi
@@ -211,16 +211,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l422rbix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422rbix-pinctrl.dtsi
@@ -347,26 +347,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l422rbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422rbtx-pinctrl.dtsi
@@ -347,26 +347,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l422tbyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422tbyx-pinctrl.dtsi
@@ -222,16 +222,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l431c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)tx-pinctrl.dtsi
@@ -297,31 +297,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l431c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)ux-pinctrl.dtsi
@@ -297,31 +297,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l431c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)yx-pinctrl.dtsi
@@ -306,31 +306,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l431k(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431k(b-c)ux-pinctrl.dtsi
@@ -222,21 +222,25 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l431r(b-c)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)ix-pinctrl.dtsi
@@ -405,36 +405,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l431r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)tx-pinctrl.dtsi
@@ -405,36 +405,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l431r(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)yx-pinctrl.dtsi
@@ -405,36 +405,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l431vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431vcix-pinctrl.dtsi
@@ -499,46 +499,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l431vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431vctx-pinctrl.dtsi
@@ -499,46 +499,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l432k(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l432k(b-c)ux-pinctrl.dtsi
@@ -222,21 +222,25 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
@@ -297,31 +297,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
@@ -297,31 +297,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
@@ -306,31 +306,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
@@ -405,36 +405,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
@@ -405,36 +405,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
@@ -405,36 +405,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
@@ -349,36 +349,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l433vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vcix-pinctrl.dtsi
@@ -499,46 +499,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l433vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vctx-pinctrl.dtsi
@@ -499,46 +499,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l442kcux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l442kcux-pinctrl.dtsi
@@ -222,21 +222,25 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l443cctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443cctx-pinctrl.dtsi
@@ -297,31 +297,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l443ccux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccux-pinctrl.dtsi
@@ -297,31 +297,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
@@ -306,31 +306,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l443rcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcix-pinctrl.dtsi
@@ -405,36 +405,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l443rctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rctx-pinctrl.dtsi
@@ -405,36 +405,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
@@ -405,36 +405,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l443vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vcix-pinctrl.dtsi
@@ -499,46 +499,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l443vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vctx-pinctrl.dtsi
@@ -499,46 +499,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l451c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451c(c-e)ux-pinctrl.dtsi
@@ -335,31 +335,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l451cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451cetx-pinctrl.dtsi
@@ -335,31 +335,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l451r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)ix-pinctrl.dtsi
@@ -455,36 +455,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l451r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)tx-pinctrl.dtsi
@@ -455,36 +455,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l451r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)yx-pinctrl.dtsi
@@ -455,36 +455,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l451v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451v(c-e)ix-pinctrl.dtsi
@@ -561,46 +561,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l451v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451v(c-e)tx-pinctrl.dtsi
@@ -561,46 +561,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l452c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452c(c-e)ux-pinctrl.dtsi
@@ -335,31 +335,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l452cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452cetx-pinctrl.dtsi
@@ -335,31 +335,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
@@ -455,36 +455,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
@@ -455,36 +455,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
@@ -455,36 +455,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l452retxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452retxp-pinctrl.dtsi
@@ -399,36 +399,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
@@ -561,46 +561,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
@@ -561,46 +561,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l462cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462cetx-pinctrl.dtsi
@@ -335,31 +335,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l462ceux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462ceux-pinctrl.dtsi
@@ -335,31 +335,37 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l462reix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reix-pinctrl.dtsi
@@ -455,36 +455,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l462retx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462retx-pinctrl.dtsi
@@ -455,36 +455,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l462reyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reyx-pinctrl.dtsi
@@ -455,36 +455,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l462veix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462veix-pinctrl.dtsi
@@ -561,46 +561,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l462vetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462vetx-pinctrl.dtsi
@@ -561,46 +561,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
@@ -903,51 +903,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l471r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471r(e-g)tx-pinctrl.dtsi
@@ -436,31 +436,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
@@ -699,41 +699,49 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
@@ -923,51 +923,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
@@ -923,51 +923,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
@@ -436,31 +436,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
@@ -699,41 +699,49 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
@@ -463,36 +463,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
@@ -450,36 +450,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
@@ -468,36 +468,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
@@ -903,51 +903,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
@@ -436,31 +436,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
@@ -699,41 +699,49 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
@@ -923,51 +923,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
@@ -923,51 +923,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
@@ -912,51 +912,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
@@ -463,36 +463,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
@@ -463,36 +463,43 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l486qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486qgix-pinctrl.dtsi
@@ -903,51 +903,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
@@ -436,31 +436,37 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
@@ -699,41 +699,49 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
@@ -923,51 +923,61 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
@@ -1158,71 +1158,85 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l496agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496agixp-pinctrl.dtsi
@@ -1158,71 +1158,85 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
@@ -1096,66 +1096,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
@@ -1067,66 +1067,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
@@ -563,41 +563,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
@@ -503,41 +503,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
@@ -868,56 +868,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
@@ -845,56 +845,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
@@ -831,56 +831,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
@@ -823,56 +823,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
@@ -921,61 +921,73 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
@@ -1141,66 +1141,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
@@ -1124,66 +1124,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
@@ -1158,71 +1158,85 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
@@ -1158,71 +1158,85 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
@@ -1096,66 +1096,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
@@ -1067,66 +1067,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
@@ -563,41 +563,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
@@ -550,41 +550,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
@@ -868,56 +868,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
@@ -845,56 +845,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
@@ -831,56 +831,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
@@ -823,56 +823,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
@@ -1141,66 +1141,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
@@ -1124,66 +1124,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
@@ -1105,71 +1105,85 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
@@ -1105,71 +1105,85 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
@@ -349,36 +349,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
@@ -349,36 +349,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
@@ -321,36 +321,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
@@ -321,36 +321,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
@@ -1057,66 +1057,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
@@ -1033,66 +1033,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
@@ -530,41 +530,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
@@ -517,41 +517,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
@@ -801,56 +801,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
@@ -807,56 +807,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
@@ -783,56 +783,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
@@ -799,56 +799,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
@@ -1057,66 +1057,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
@@ -1045,66 +1045,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
@@ -1105,71 +1105,85 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4q5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agixp-pinctrl.dtsi
@@ -1105,71 +1105,85 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
@@ -349,36 +349,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4q5cgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgtxp-pinctrl.dtsi
@@ -321,36 +321,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
@@ -349,36 +349,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4q5cguxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cguxp-pinctrl.dtsi
@@ -321,36 +321,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
@@ -1057,66 +1057,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4q5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgixp-pinctrl.dtsi
@@ -1033,66 +1033,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
@@ -530,41 +530,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4q5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtxp-pinctrl.dtsi
@@ -517,41 +517,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
@@ -801,56 +801,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4q5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtxp-pinctrl.dtsi
@@ -783,56 +783,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
@@ -807,56 +807,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4q5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyxp-pinctrl.dtsi
@@ -799,56 +799,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
@@ -1057,66 +1057,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4q5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtxp-pinctrl.dtsi
@@ -1045,66 +1045,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
@@ -926,71 +926,85 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
@@ -878,66 +878,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
@@ -662,56 +662,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
@@ -878,66 +878,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
@@ -861,66 +861,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
@@ -866,66 +866,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
@@ -926,71 +926,85 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
@@ -662,56 +662,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
@@ -878,66 +878,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
@@ -904,71 +904,85 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
@@ -610,56 +610,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
@@ -861,66 +861,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
@@ -850,66 +850,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
@@ -861,66 +861,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
@@ -837,66 +837,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
@@ -926,71 +926,85 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
@@ -878,66 +878,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
@@ -662,56 +662,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
@@ -878,66 +878,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
@@ -861,66 +861,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
@@ -926,71 +926,85 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
@@ -662,56 +662,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
@@ -878,66 +878,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
@@ -904,71 +904,85 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
@@ -610,56 +610,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
@@ -861,66 +861,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
@@ -850,66 +850,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
@@ -861,66 +861,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
@@ -305,36 +305,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
@@ -305,36 +305,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
@@ -278,36 +278,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
@@ -278,36 +278,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
@@ -496,51 +496,61 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
@@ -486,46 +486,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
@@ -909,66 +909,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l552qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeix-pinctrl.dtsi
@@ -938,66 +938,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
@@ -933,66 +933,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
@@ -467,41 +467,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l552retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxp-pinctrl.dtsi
@@ -382,41 +382,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l552retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxq-pinctrl.dtsi
@@ -409,41 +409,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
@@ -695,56 +695,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l552vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552vetx-pinctrl.dtsi
@@ -722,56 +722,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
@@ -912,66 +912,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l552zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552zetx-pinctrl.dtsi
@@ -938,66 +938,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l562cetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetx-pinctrl.dtsi
@@ -305,36 +305,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
@@ -278,36 +278,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l562ceux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceux-pinctrl.dtsi
@@ -305,36 +305,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
@@ -278,36 +278,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
@@ -496,51 +496,61 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
@@ -486,46 +486,55 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l562qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeix-pinctrl.dtsi
@@ -938,66 +938,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
@@ -933,66 +933,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
@@ -909,66 +909,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l562retx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retx-pinctrl.dtsi
@@ -467,41 +467,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l562retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxp-pinctrl.dtsi
@@ -382,41 +382,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l562retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxq-pinctrl.dtsi
@@ -409,41 +409,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l562vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetx-pinctrl.dtsi
@@ -722,56 +722,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
@@ -695,56 +695,67 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l562zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetx-pinctrl.dtsi
@@ -938,66 +938,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
@@ -912,66 +912,79 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pe13: spi1_sck_pe13 {
 				pinmux = <STM32_PINMUX('E', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pg2: spi1_sck_pg2 {
 				pinmux = <STM32_PINMUX('G', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pg9: spi3_sck_pg9 {
 				pinmux = <STM32_PINMUX('G', 9, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
@@ -1839,101 +1839,121 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
@@ -1347,76 +1347,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
@@ -1824,96 +1824,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
@@ -1347,76 +1347,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
@@ -1839,101 +1839,121 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
@@ -1347,76 +1347,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
@@ -1824,96 +1824,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
@@ -1347,76 +1347,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
@@ -1839,101 +1839,121 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
@@ -1347,76 +1347,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
@@ -1824,96 +1824,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
@@ -1347,76 +1347,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
@@ -1839,101 +1839,121 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
@@ -1347,76 +1347,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
@@ -1824,96 +1824,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
@@ -1347,76 +1347,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
@@ -1895,101 +1895,121 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
@@ -1391,76 +1391,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
@@ -1880,96 +1880,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
@@ -1391,76 +1391,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
@@ -1895,101 +1895,121 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
@@ -1391,76 +1391,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
@@ -1880,96 +1880,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
@@ -1391,76 +1391,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
@@ -1895,101 +1895,121 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
@@ -1391,76 +1391,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
@@ -1880,96 +1880,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
@@ -1391,76 +1391,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
@@ -1895,101 +1895,121 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
@@ -1391,76 +1391,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
@@ -1880,96 +1880,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
@@ -1391,76 +1391,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
@@ -1895,101 +1895,121 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
@@ -1391,76 +1391,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
@@ -1880,96 +1880,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
@@ -1391,76 +1391,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
@@ -1895,101 +1895,121 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
@@ -1391,76 +1391,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
@@ -1880,96 +1880,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
@@ -1391,76 +1391,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
@@ -1895,101 +1895,121 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
@@ -1391,76 +1391,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
@@ -1880,96 +1880,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
@@ -1391,76 +1391,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
@@ -1895,101 +1895,121 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pk0: spi5_sck_pk0 {
 				pinmux = <STM32_PINMUX('K', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
@@ -1391,76 +1391,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
@@ -1880,96 +1880,115 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pz0: spi1_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pi1: spi2_sck_pi1 {
 				pinmux = <STM32_PINMUX('I', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_ph6: spi5_sck_ph6 {
 				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pz0: spi6_sck_pz0 {
 				pinmux = <STM32_PINMUX('Z', 0, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
@@ -1391,76 +1391,91 @@
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pb3: spi3_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pc10: spi3_sck_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF6)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi3_sck_pe0: spi3_sck_pe0 {
 				pinmux = <STM32_PINMUX('E', 0, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe2: spi4_sck_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi4_sck_pe12: spi4_sck_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi5_sck_pf7: spi5_sck_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pa5: spi6_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pb3: spi6_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF8)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi6_sck_pg13: spi6_sck_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb10ccux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb10ccux-pinctrl.dtsi
@@ -167,16 +167,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb15ccux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb15ccux-pinctrl.dtsi
@@ -167,16 +167,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb15ccuxe-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb15ccuxe-pinctrl.dtsi
@@ -167,16 +167,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb15ccyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb15ccyx-pinctrl.dtsi
@@ -156,11 +156,13 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb30ceuxa-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb30ceuxa-pinctrl.dtsi
@@ -147,16 +147,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb35c(c-e)uxa-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb35c(c-e)uxa-pinctrl.dtsi
@@ -191,16 +191,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb50cgux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb50cgux-pinctrl.dtsi
@@ -147,16 +147,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb55ccux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55ccux-pinctrl.dtsi
@@ -191,16 +191,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb55ceux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55ceux-pinctrl.dtsi
@@ -191,16 +191,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb55cgux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55cgux-pinctrl.dtsi
@@ -191,16 +191,19 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
@@ -301,36 +301,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb55revx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55revx-pinctrl.dtsi
@@ -301,36 +301,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
@@ -301,36 +301,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
@@ -336,41 +336,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
@@ -336,41 +336,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
@@ -336,41 +336,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
@@ -336,41 +336,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
@@ -336,41 +336,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
@@ -336,41 +336,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb55vyyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vyyx-pinctrl.dtsi
@@ -336,41 +336,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
@@ -336,41 +336,49 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd1: spi2_sck_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pd3: spi2_sck_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wl/stm32wl54ccux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wl54ccux-pinctrl.dtsi
@@ -221,26 +221,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wl/stm32wl54jcix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wl54jcix-pinctrl.dtsi
@@ -337,36 +337,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wl/stm32wl55ccux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wl55ccux-pinctrl.dtsi
@@ -221,26 +221,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wl/stm32wl55jcix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wl55jcix-pinctrl.dtsi
@@ -337,36 +337,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wl/stm32wl55ucyx-pinctrl.dtsi
+++ b/dts/st/wl/stm32wl55ucyx-pinctrl.dtsi
@@ -180,26 +180,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wl/stm32wle4c8ux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4c8ux-pinctrl.dtsi
@@ -221,26 +221,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wl/stm32wle4cbux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4cbux-pinctrl.dtsi
@@ -221,26 +221,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wl/stm32wle4ccux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4ccux-pinctrl.dtsi
@@ -221,26 +221,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wl/stm32wle4j8ix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4j8ix-pinctrl.dtsi
@@ -337,36 +337,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wl/stm32wle4jbix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4jbix-pinctrl.dtsi
@@ -337,36 +337,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wl/stm32wle4jcix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4jcix-pinctrl.dtsi
@@ -337,36 +337,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wl/stm32wle5c8ux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5c8ux-pinctrl.dtsi
@@ -221,26 +221,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wl/stm32wle5cbux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5cbux-pinctrl.dtsi
@@ -221,26 +221,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wl/stm32wle5ccux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5ccux-pinctrl.dtsi
@@ -221,26 +221,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wl/stm32wle5j8ix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5j8ix-pinctrl.dtsi
@@ -337,36 +337,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wl/stm32wle5jbix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5jbix-pinctrl.dtsi
@@ -337,36 +337,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wl/stm32wle5jcix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5jcix-pinctrl.dtsi
@@ -337,36 +337,43 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb10: spi2_sck_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pb13: spi2_sck_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wl/stm32wle5u8yx-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5u8yx-pinctrl.dtsi
@@ -180,26 +180,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/wl/stm32wle5ubyx-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5ubyx-pinctrl.dtsi
@@ -180,26 +180,31 @@
 
 			spi1_sck_pa1: spi1_sck_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pa5: spi1_sck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi1_sck_pb3: spi1_sck_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa8: spi2_sck_pa8 {
 				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 
 			spi2_sck_pa9: spi2_sck_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				bias-pull-down;
 				slew-rate = "very-high-speed";
 			};
 

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -191,6 +191,7 @@
 - name: SPI_SCK
   match: "^SPI\\d+_SCK$"
   slew-rate: very-high-speed
+  bias: pull-down
 
 - name: SPI_NSS
   match: "^SPI\\d+_NSS$"


### PR DESCRIPTION
These two patches are basically the conversion of the https://github.com/zephyrproject-rtos/zephyr/pull/24097 fix to the new device tree bindings for SPI pins configuration.