### PR TITLE
dts/st/h7: stm32h743vitx: MCO pin control definitions added 

### DIFF
--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -818,6 +818,18 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+            /* MCO */
+
+            mco1_pa8: mco1_pa8 {
+                pinmux = <STM32_PINMUX('A', 8, AF0)>;
+                slew-rate = "very-high-speed";
+            };
+
+            mco2_pc9: mco2_pc9 {
+                pinmux = <STM32_PINMUX('C', 9, AF0)>;
+                slew-rate = "very-high-speed";
+            };
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
@@ -1917,13 +1929,6 @@
 				bias-pull-up;
 			};
 
-            /* UART_DE / USART_DE / LPUART_DE */
-
-            uart2_de_pd4: uart2_de_pd4 {
-                pinmux = <STM32_PINMUX('D', 4, AF7)>;
-                bias-pull-down;
-            };
-
 			/* USB_OTG_FS */
 
 			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {
@@ -2013,18 +2018,6 @@
 			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
-
-            /* MCO */
-
-            mco1_pa8: mco1_pa8 {
-                pinmux = <STM32_PINMUX('A', 8, AF0)>;
-                slew-rate = "very-high-speed";
-            };
-
-            mco2_pc9: mco2_pc9 {
-                pinmux = <STM32_PINMUX('C', 9, AF0)>;
-                slew-rate = "very-high-speed";
-            };
 
 		};
 	};

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -2392,13 +2392,6 @@
 				bias-pull-up;
 			};
 
-            /* UART_DE / USART_DE / LPUART_DE */
-
-            uart2_de_pd4: uart2_de_pd4 {
-                pinmux = <STM32_PINMUX('D', 4, AF7)>;
-                bias-pull-down;
-            };
-
 			/* USB_OTG_FS */
 
 			usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {


### PR DESCRIPTION
dts/st/h7: stm32h743vitx: MCO pin control definitions added 

Signed-off-by: Raphael Löffel <loeffel@rte-ag.ch>