### PR TITLE
scripts: serie_update: manage stm32_assert.h file

### DIFF
--- a/scripts/stm32_assert_template.txt
+++ b/scripts/stm32_assert_template.txt
@@ -1,0 +1,7 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2021 STMicroelectronics
+ */
+
+#include <{{ stm32serie }}xx_hal_conf.h>
+


### PR DESCRIPTION
scripts: serie_update: manage stm32_assert.h file

Remove useless stm32_assert_template.h
create stm32_assert.h thanks to Jinja2 template

Script automation corresponding to https://github.com/zephyrproject-rtos/hal_stm32/pull/100