### PR TITLE
asserts: stm32: Fixes build issues when asserts are enabled

### DIFF
--- a/stm32cube/stm32f0xx/drivers/include/stm32_assert.h
+++ b/stm32cube/stm32f0xx/drivers/include/stm32_assert.h
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier : Apache-2.0
-# Copyright (c) 2021 STMicroelectronics
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2021 STMicroelectronics
+ */
 
 #include <stm32f0xx_hal_conf.h>

--- a/stm32cube/stm32f1xx/drivers/include/stm32_assert.h
+++ b/stm32cube/stm32f1xx/drivers/include/stm32_assert.h
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier : Apache-2.0
-# Copyright (c) 2021 STMicroelectronics
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2021 STMicroelectronics
+ */
 
 #include <stm32f1xx_hal_conf.h>

--- a/stm32cube/stm32f2xx/drivers/include/stm32_assert.h
+++ b/stm32cube/stm32f2xx/drivers/include/stm32_assert.h
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier : Apache-2.0
-# Copyright (c) 2021 STMicroelectronics
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2021 STMicroelectronics
+ */
 
 #include <stm32f2xx_hal_conf.h>

--- a/stm32cube/stm32f3xx/drivers/include/stm32_assert.h
+++ b/stm32cube/stm32f3xx/drivers/include/stm32_assert.h
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier : Apache-2.0
-# Copyright (c) 2021 STMicroelectronics
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2021 STMicroelectronics
+ */
 
 #include <stm32f3xx_hal_conf.h>

--- a/stm32cube/stm32f4xx/drivers/include/stm32_assert.h
+++ b/stm32cube/stm32f4xx/drivers/include/stm32_assert.h
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier : Apache-2.0
-# Copyright (c) 2021 STMicroelectronics
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2021 STMicroelectronics
+ */
 
 #include <stm32f4xx_hal_conf.h>

--- a/stm32cube/stm32f7xx/drivers/include/stm32_assert.h
+++ b/stm32cube/stm32f7xx/drivers/include/stm32_assert.h
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier : Apache-2.0
-# Copyright (c) 2021 STMicroelectronics
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2021 STMicroelectronics
+ */
 
 #include <stm32f7xx_hal_conf.h>

--- a/stm32cube/stm32g0xx/drivers/include/stm32_assert.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32_assert.h
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier : Apache-2.0
-# Copyright (c) 2021 STMicroelectronics
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2021 STMicroelectronics
+ */
 
 #include <stm32g0xx_hal_conf.h>

--- a/stm32cube/stm32g4xx/drivers/include/stm32_assert.h
+++ b/stm32cube/stm32g4xx/drivers/include/stm32_assert.h
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier : Apache-2.0
-# Copyright (c) 2021 STMicroelectronics
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2021 STMicroelectronics
+ */
 
 #include <stm32g4xx_hal_conf.h>

--- a/stm32cube/stm32h7xx/drivers/include/stm32_assert.h
+++ b/stm32cube/stm32h7xx/drivers/include/stm32_assert.h
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier : Apache-2.0
-# Copyright (c) 2021 STMicroelectronics
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2021 STMicroelectronics
+ */
 
 #include <stm32h7xx_hal_conf.h>

--- a/stm32cube/stm32l0xx/drivers/include/stm32_assert.h
+++ b/stm32cube/stm32l0xx/drivers/include/stm32_assert.h
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier : Apache-2.0
-# Copyright (c) 2021 STMicroelectronics
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2021 STMicroelectronics
+ */
 
 #include <stm32l0xx_hal_conf.h>

--- a/stm32cube/stm32l1xx/drivers/include/stm32_assert.h
+++ b/stm32cube/stm32l1xx/drivers/include/stm32_assert.h
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier : Apache-2.0
-# Copyright (c) 2021 STMicroelectronics
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2021 STMicroelectronics
+ */
 
 #include <stm32l1xx_hal_conf.h>

--- a/stm32cube/stm32l4xx/drivers/include/stm32_assert.h
+++ b/stm32cube/stm32l4xx/drivers/include/stm32_assert.h
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier : Apache-2.0
-# Copyright (c) 2021 STMicroelectronics
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2021 STMicroelectronics
+ */
 
 #include <stm32l4xx_hal_conf.h>

--- a/stm32cube/stm32l5xx/drivers/include/stm32_assert.h
+++ b/stm32cube/stm32l5xx/drivers/include/stm32_assert.h
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier : Apache-2.0
-# Copyright (c) 2021 STMicroelectronics
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2021 STMicroelectronics
+ */
 
 #include <stm32l5xx_hal_conf.h>

--- a/stm32cube/stm32mp1xx/drivers/include/stm32_assert.h
+++ b/stm32cube/stm32mp1xx/drivers/include/stm32_assert.h
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier : Apache-2.0
-# Copyright (c) 2021 STMicroelectronics
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2021 STMicroelectronics
+ */
 
 #include <stm32mp1xx_hal_conf.h>

--- a/stm32cube/stm32wbxx/drivers/include/stm32_assert.h
+++ b/stm32cube/stm32wbxx/drivers/include/stm32_assert.h
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier : Apache-2.0
-# Copyright (c) 2021 STMicroelectronics
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2021 STMicroelectronics
+ */
 
 #include <stm32wbxx_hal_conf.h>

--- a/stm32cube/stm32wlxx/drivers/include/stm32_assert.h
+++ b/stm32cube/stm32wlxx/drivers/include/stm32_assert.h
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier : Apache-2.0
-# Copyright (c) 2021 STMicroelectronics
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2021 STMicroelectronics
+ */
 
 #include <stm32wlxx_hal_conf.h>


### PR DESCRIPTION
This commit fixes the build issues due to incorrect usage of "#" as
a beginning of comments in stm32_assert.h on all series, hence "#"
is replaced by C style comments.

Signed-off-by: Krishna Mohan Dani <krishnamohan.d@hcl.com>