### PR TITLE
dts: Provide updated *-pinctrl.dtsi based on CubeMx6.3

### DIFF
--- a/dts/README.md
+++ b/dts/README.md
@@ -31,7 +31,7 @@ URL:
    https://github.com/STMicroelectronics/STM32_open_pin_data
 
 Commit:
-   d1b80258bc63add9baad70be0ef74f3c4301ac58
+   84963babb708a3465cf4913a83a9d7cb8e5ac13f
 
 Maintained-by:
    External

--- a/dts/st/f0/stm32f030r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030r8tx-pinctrl.dtsi
@@ -274,7 +274,7 @@
 			};
 
 			tim3_ch3_pc8: tim3_ch3_pc8 {
-				pinmux = <STM32_PINMUX('C', 8, AF1)>;
+				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
 			tim3_ch4_pc9: tim3_ch4_pc9 {

--- a/dts/st/f0/stm32f051r4tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r4tx-pinctrl.dtsi
@@ -324,7 +324,7 @@
 			};
 
 			tim3_ch3_pc8: tim3_ch3_pc8 {
-				pinmux = <STM32_PINMUX('C', 8, AF1)>;
+				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
 			tim3_ch4_pc9: tim3_ch4_pc9 {

--- a/dts/st/f0/stm32f051r6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r6tx-pinctrl.dtsi
@@ -324,7 +324,7 @@
 			};
 
 			tim3_ch3_pc8: tim3_ch3_pc8 {
-				pinmux = <STM32_PINMUX('C', 8, AF1)>;
+				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
 			tim3_ch4_pc9: tim3_ch4_pc9 {

--- a/dts/st/f0/stm32f051r8hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r8hx-pinctrl.dtsi
@@ -348,7 +348,7 @@
 			};
 
 			tim3_ch3_pc8: tim3_ch3_pc8 {
-				pinmux = <STM32_PINMUX('C', 8, AF1)>;
+				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
 			tim3_ch4_pc9: tim3_ch4_pc9 {

--- a/dts/st/f0/stm32f051r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r8tx-pinctrl.dtsi
@@ -348,7 +348,7 @@
 			};
 
 			tim3_ch3_pc8: tim3_ch3_pc8 {
-				pinmux = <STM32_PINMUX('C', 8, AF1)>;
+				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
 			tim3_ch4_pc9: tim3_ch4_pc9 {

--- a/dts/st/f0/stm32f058r8hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058r8hx-pinctrl.dtsi
@@ -348,7 +348,7 @@
 			};
 
 			tim3_ch3_pc8: tim3_ch3_pc8 {
-				pinmux = <STM32_PINMUX('C', 8, AF1)>;
+				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
 			tim3_ch4_pc9: tim3_ch4_pc9 {

--- a/dts/st/f0/stm32f058r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058r8tx-pinctrl.dtsi
@@ -348,7 +348,7 @@
 			};
 
 			tim3_ch3_pc8: tim3_ch3_pc8 {
-				pinmux = <STM32_PINMUX('C', 8, AF1)>;
+				pinmux = <STM32_PINMUX('C', 8, AF0)>;
 			};
 
 			tim3_ch4_pc9: tim3_ch4_pc9 {

--- a/dts/st/g0/stm32g030j6mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030j6mx-pinctrl.dtsi
@@ -291,10 +291,22 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -309,6 +321,10 @@
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
 
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
+			};
+
 			/* UART_TX / USART_TX / LPUART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
@@ -318,6 +334,16 @@
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa2: usart2_tx_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g031c(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031c(4-6-8)ux-pinctrl.dtsi
@@ -64,10 +64,6 @@
 				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
 			};
 
-			adc1_in11_pb7: adc1_in11_pb7 {
-				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
-			};
-
 			adc1_in11_pb10: adc1_in11_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
 			};

--- a/dts/st/g0/stm32g031j(4-6)mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031j(4-6)mx-pinctrl.dtsi
@@ -307,6 +307,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -321,6 +327,12 @@
 				drive-open-drain;
 			};
 
+			usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
@@ -329,6 +341,10 @@
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
@@ -345,6 +361,16 @@
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa2: usart2_tx_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g041c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041c(6-8)ux-pinctrl.dtsi
@@ -64,10 +64,6 @@
 				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
 			};
 
-			adc1_in11_pb7: adc1_in11_pb7 {
-				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
-			};
-
 			adc1_in11_pb10: adc1_in11_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
 			};

--- a/dts/st/g0/stm32g041j6mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041j6mx-pinctrl.dtsi
@@ -307,6 +307,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -321,6 +327,12 @@
 				drive-open-drain;
 			};
 
+			usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
@@ -329,6 +341,10 @@
 
 			usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
+			};
+
+			usart2_rx_pa15: usart2_rx_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF1)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
@@ -345,6 +361,16 @@
 
 			usart1_tx_pb6: usart1_tx_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF0)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa2: usart2_tx_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF1)>;
+				bias-pull-up;
+			};
+
+			usart2_tx_pa14: usart2_tx_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0b0ketx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0ketx-pinctrl.dtsi
@@ -793,28 +793,6 @@
 				bias-pull-up;
 			};
 
-			/* USB */
-
-			usb_noe_pa4: usb_noe_pa4 {
-				pinmux = <STM32_PINMUX('A', 4, AF2)>;
-			};
-
-			usb_dm_pa11: usb_dm_pa11 {
-				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
-			};
-
-			usb_dp_pa12: usb_dp_pa12 {
-				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
-			};
-
-			usb_noe_pa13: usb_noe_pa13 {
-				pinmux = <STM32_PINMUX('A', 13, AF2)>;
-			};
-
-			usb_noe_pa15: usb_noe_pa15 {
-				pinmux = <STM32_PINMUX('A', 15, AF6)>;
-			};
-
 		};
 	};
 };

--- a/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
@@ -789,6 +789,12 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF14)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -817,6 +823,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -861,6 +873,10 @@
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+			};
+
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
@@ -917,6 +933,11 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF5)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
@@ -833,6 +833,12 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF14)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -861,6 +867,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -905,6 +917,10 @@
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+			};
+
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
@@ -961,6 +977,11 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF5)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
@@ -927,6 +927,12 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF14)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -955,6 +961,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -999,6 +1011,10 @@
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+			};
+
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
@@ -1055,6 +1071,11 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF5)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g4/stm32g483ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483ceux-pinctrl.dtsi
@@ -833,6 +833,12 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF14)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -861,6 +867,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -905,6 +917,10 @@
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+			};
+
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
@@ -961,6 +977,11 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF5)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g4/stm32g484ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484ceux-pinctrl.dtsi
@@ -927,6 +927,12 @@
 				drive-open-drain;
 			};
 
+			uart4_cts_pb7: uart4_cts_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF14)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {
@@ -955,6 +961,12 @@
 
 			usart3_rts_pb14: usart3_rts_pb14 {
 				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart4_rts_pa15: uart4_rts_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -999,6 +1011,10 @@
 
 			usart3_rx_pc11: usart3_rx_pc11 {
 				pinmux = <STM32_PINMUX('C', 11, AF7)>;
+			};
+
+			uart4_rx_pc11: uart4_rx_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
@@ -1055,6 +1071,11 @@
 
 			usart3_tx_pc10: usart3_tx_pc10 {
 				pinmux = <STM32_PINMUX('C', 10, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pc10: uart4_tx_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF5)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h735vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vghx-pinctrl.dtsi
@@ -1685,6 +1685,12 @@
 				drive-open-drain;
 			};
 
+			uart9_cts_pd0: uart9_cts_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
@@ -1753,7 +1759,17 @@
 				drive-open-drain;
 			};
 
+			uart9_rts_pd13: uart9_rts_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RX / USART_RX / LPUART_RX */
+
+			usart10_rx_pe2: usart10_rx_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF4)>;
+			};
 
 			lpuart1_rx_pa10: lpuart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
@@ -1847,7 +1863,16 @@
 				pinmux = <STM32_PINMUX('E', 0, AF8)>;
 			};
 
+			uart9_rx_pd14: uart9_rx_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
 			/* UART_TX / USART_TX / LPUART_TX */
+
+			usart10_tx_pe3: usart10_tx_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				bias-pull-up;
+			};
 
 			lpuart1_tx_pa9: lpuart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF3)>;
@@ -1961,6 +1986,11 @@
 
 			uart8_tx_pe1: uart8_tx_pe1 {
 				pinmux = <STM32_PINMUX('E', 1, AF8)>;
+				bias-pull-up;
+			};
+
+			uart9_tx_pd15: uart9_tx_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
@@ -1592,6 +1592,12 @@
 				drive-open-drain;
 			};
 
+			uart9_cts_pd0: uart9_cts_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {
@@ -1650,6 +1656,12 @@
 
 			uart8_rts_pd15: uart8_rts_pd15 {
 				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			uart9_rts_pd13: uart9_rts_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -1738,6 +1750,10 @@
 
 			uart7_rx_pe7: uart7_rx_pe7 {
 				pinmux = <STM32_PINMUX('E', 7, AF7)>;
+			};
+
+			uart9_rx_pd14: uart9_rx_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
@@ -1849,6 +1865,11 @@
 
 			uart7_tx_pe8: uart7_tx_pe8 {
 				pinmux = <STM32_PINMUX('E', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart9_tx_pd15: uart9_tx_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -451,6 +451,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			eth_txd3_pb8: eth_txd3_pb8 {
@@ -460,6 +467,13 @@
 
 			eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -559,6 +573,18 @@
 
 			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1645,6 +1671,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -1719,6 +1750,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2839,6 +2875,14 @@
 
 			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -451,6 +451,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			eth_txd3_pb8: eth_txd3_pb8 {
@@ -460,6 +467,13 @@
 
 			eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -559,6 +573,18 @@
 
 			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1645,6 +1671,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -1719,6 +1750,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2839,6 +2875,14 @@
 
 			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -377,6 +377,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -422,6 +427,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -461,6 +471,11 @@
 			};
 
 			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -522,6 +537,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			eth_txd3_pb8: eth_txd3_pb8 {
@@ -535,6 +555,11 @@
 			};
 
 			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -643,6 +668,18 @@
 
 			fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1429,6 +1466,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -1641,6 +1683,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -1740,6 +1788,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -1819,6 +1872,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2198,6 +2256,14 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			tim2_ch1_pa0: tim2_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
+			tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
 			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -2336,6 +2402,18 @@
 
 			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim5_ch1_pa0: tim5_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -2542,6 +2620,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -2618,6 +2702,12 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -2734,6 +2824,10 @@
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+			};
+
+			uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
@@ -2857,6 +2951,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3029,6 +3128,14 @@
 
 			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -377,6 +377,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -422,6 +427,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -461,6 +471,11 @@
 			};
 
 			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -522,6 +537,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			eth_txd3_pb8: eth_txd3_pb8 {
@@ -535,6 +555,11 @@
 			};
 
 			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -643,6 +668,18 @@
 
 			fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1429,6 +1466,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -1641,6 +1683,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -1740,6 +1788,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -1819,6 +1872,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2198,6 +2256,14 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			tim2_ch1_pa0: tim2_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
+			tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
 			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -2336,6 +2402,18 @@
 
 			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim5_ch1_pa0: tim5_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -2542,6 +2620,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -2618,6 +2702,12 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -2734,6 +2824,10 @@
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+			};
+
+			uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
@@ -2857,6 +2951,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3029,6 +3128,14 @@
 
 			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -377,6 +377,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -422,6 +427,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -461,6 +471,11 @@
 			};
 
 			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -522,6 +537,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			eth_txd3_pb8: eth_txd3_pb8 {
@@ -535,6 +555,11 @@
 			};
 
 			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -643,6 +668,18 @@
 
 			fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1429,6 +1466,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -1641,6 +1683,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -1740,6 +1788,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -1819,6 +1872,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2198,6 +2256,14 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			tim2_ch1_pa0: tim2_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
+			tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
 			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -2336,6 +2402,18 @@
 
 			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim5_ch1_pa0: tim5_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -2542,6 +2620,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -2618,6 +2702,12 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -2734,6 +2824,10 @@
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+			};
+
+			uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
@@ -2857,6 +2951,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3029,6 +3128,14 @@
 
 			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -377,6 +377,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -422,6 +427,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -461,6 +471,11 @@
 			};
 
 			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -517,6 +532,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			eth_txd3_pb8: eth_txd3_pb8 {
@@ -530,6 +550,11 @@
 			};
 
 			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -634,6 +659,18 @@
 
 			fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1351,6 +1388,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -1563,6 +1605,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -1662,6 +1710,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1731,6 +1784,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2054,6 +2112,14 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			tim2_ch1_pa0: tim2_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
+			tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
 			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -2192,6 +2258,18 @@
 
 			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim5_ch1_pa0: tim5_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -2346,6 +2424,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -2422,6 +2506,12 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -2544,6 +2634,10 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
+			uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -2653,6 +2747,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -2820,6 +2919,14 @@
 
 			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -377,6 +377,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -422,6 +427,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -461,6 +471,11 @@
 			};
 
 			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -517,6 +532,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			eth_txd3_pb8: eth_txd3_pb8 {
@@ -530,6 +550,11 @@
 			};
 
 			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -634,6 +659,18 @@
 
 			fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1351,6 +1388,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -1563,6 +1605,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -1662,6 +1710,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1731,6 +1784,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2054,6 +2112,14 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			tim2_ch1_pa0: tim2_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
+			tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
 			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -2192,6 +2258,18 @@
 
 			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim5_ch1_pa0: tim5_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -2346,6 +2424,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -2422,6 +2506,12 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -2544,6 +2634,10 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
+			uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -2653,6 +2747,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -2820,6 +2919,14 @@
 
 			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -377,6 +377,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -422,6 +427,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -461,6 +471,11 @@
 			};
 
 			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -522,6 +537,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			eth_txd3_pb8: eth_txd3_pb8 {
@@ -535,6 +555,11 @@
 			};
 
 			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -643,6 +668,18 @@
 
 			fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1429,6 +1466,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -1641,6 +1683,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -1740,6 +1788,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -1819,6 +1872,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2198,6 +2256,14 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			tim2_ch1_pa0: tim2_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
+			tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
 			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -2336,6 +2402,18 @@
 
 			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim5_ch1_pa0: tim5_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -2542,6 +2620,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -2618,6 +2702,12 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -2734,6 +2824,10 @@
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+			};
+
+			uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
@@ -2857,6 +2951,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3029,6 +3128,14 @@
 
 			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -377,6 +377,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -422,6 +427,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -461,6 +471,11 @@
 			};
 
 			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -522,6 +537,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			eth_txd3_pb8: eth_txd3_pb8 {
@@ -535,6 +555,11 @@
 			};
 
 			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -643,6 +668,18 @@
 
 			fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1429,6 +1466,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -1641,6 +1683,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -1740,6 +1788,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -1819,6 +1872,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2198,6 +2256,14 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			tim2_ch1_pa0: tim2_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
+			tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
 			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -2336,6 +2402,18 @@
 
 			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim5_ch1_pa0: tim5_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -2542,6 +2620,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -2618,6 +2702,12 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -2734,6 +2824,10 @@
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+			};
+
+			uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
@@ -2857,6 +2951,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3029,6 +3128,14 @@
 
 			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -377,6 +377,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -422,6 +427,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -461,6 +471,11 @@
 			};
 
 			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -522,6 +537,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			eth_txd3_pb8: eth_txd3_pb8 {
@@ -535,6 +555,11 @@
 			};
 
 			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -643,6 +668,18 @@
 
 			fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1429,6 +1466,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -1641,6 +1683,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -1740,6 +1788,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -1819,6 +1872,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2198,6 +2256,14 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			tim2_ch1_pa0: tim2_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
+			tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
 			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -2336,6 +2402,18 @@
 
 			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim5_ch1_pa0: tim5_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -2542,6 +2620,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -2618,6 +2702,12 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -2734,6 +2824,10 @@
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+			};
+
+			uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
@@ -2857,6 +2951,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3029,6 +3128,14 @@
 
 			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -377,6 +377,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -422,6 +427,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -461,6 +471,11 @@
 			};
 
 			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -522,6 +537,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			eth_txd3_pb8: eth_txd3_pb8 {
@@ -535,6 +555,11 @@
 			};
 
 			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -643,6 +668,18 @@
 
 			fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1429,6 +1466,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -1641,6 +1683,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -1740,6 +1788,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -1819,6 +1872,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2198,6 +2256,14 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			tim2_ch1_pa0: tim2_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
+			tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
 			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -2336,6 +2402,18 @@
 
 			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim5_ch1_pa0: tim5_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -2542,6 +2620,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -2618,6 +2702,12 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -2734,6 +2824,10 @@
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+			};
+
+			uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
@@ -2857,6 +2951,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3029,6 +3128,14 @@
 
 			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -451,6 +451,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			eth_txd3_pb8: eth_txd3_pb8 {
@@ -460,6 +467,13 @@
 
 			eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -559,6 +573,18 @@
 
 			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1645,6 +1671,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -1719,6 +1750,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2839,6 +2875,14 @@
 
 			usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -377,6 +377,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -422,6 +427,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -461,6 +471,11 @@
 			};
 
 			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -522,6 +537,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			eth_txd3_pb8: eth_txd3_pb8 {
@@ -535,6 +555,11 @@
 			};
 
 			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -643,6 +668,18 @@
 
 			fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1429,6 +1466,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -1641,6 +1683,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -1740,6 +1788,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -1819,6 +1872,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2198,6 +2256,14 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			tim2_ch1_pa0: tim2_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
+			tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
 			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -2336,6 +2402,18 @@
 
 			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim5_ch1_pa0: tim5_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -2542,6 +2620,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -2618,6 +2702,12 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -2734,6 +2824,10 @@
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+			};
+
+			uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
@@ -2857,6 +2951,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3029,6 +3128,14 @@
 
 			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -377,6 +377,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -422,6 +427,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -461,6 +471,11 @@
 			};
 
 			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -522,6 +537,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			eth_txd3_pb8: eth_txd3_pb8 {
@@ -535,6 +555,11 @@
 			};
 
 			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -643,6 +668,18 @@
 
 			fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1429,6 +1466,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -1641,6 +1683,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -1740,6 +1788,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -1819,6 +1872,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2198,6 +2256,14 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			tim2_ch1_pa0: tim2_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
+			tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
 			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -2336,6 +2402,18 @@
 
 			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim5_ch1_pa0: tim5_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -2542,6 +2620,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -2618,6 +2702,12 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -2734,6 +2824,10 @@
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+			};
+
+			uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
@@ -2857,6 +2951,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3029,6 +3128,14 @@
 
 			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -377,6 +377,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -422,6 +427,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -461,6 +471,11 @@
 			};
 
 			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -517,6 +532,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			eth_txd3_pb8: eth_txd3_pb8 {
@@ -530,6 +550,11 @@
 			};
 
 			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -634,6 +659,18 @@
 
 			fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1351,6 +1388,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -1563,6 +1605,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -1662,6 +1710,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1731,6 +1784,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2054,6 +2112,14 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			tim2_ch1_pa0: tim2_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
+			tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
 			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -2192,6 +2258,18 @@
 
 			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim5_ch1_pa0: tim5_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -2346,6 +2424,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -2422,6 +2506,12 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -2544,6 +2634,10 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
+			uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
 			uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -2653,6 +2747,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -2820,6 +2919,14 @@
 
 			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -377,6 +377,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -422,6 +427,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -461,6 +471,11 @@
 			};
 
 			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -522,6 +537,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			eth_txd3_pb8: eth_txd3_pb8 {
@@ -535,6 +555,11 @@
 			};
 
 			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -643,6 +668,18 @@
 
 			fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1429,6 +1466,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -1641,6 +1683,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -1740,6 +1788,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -1819,6 +1872,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2198,6 +2256,14 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			tim2_ch1_pa0: tim2_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
+			tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
 			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -2336,6 +2402,18 @@
 
 			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim5_ch1_pa0: tim5_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -2542,6 +2620,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -2618,6 +2702,12 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -2734,6 +2824,10 @@
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+			};
+
+			uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
@@ -2857,6 +2951,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3029,6 +3128,14 @@
 
 			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -377,6 +377,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_crs_pa0: eth_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -422,6 +427,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_ref_clk_pa1: eth_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -461,6 +471,11 @@
 			};
 
 			/* ETH_RX_CLK */
+
+			eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -522,6 +537,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			eth_txd2_pc2: eth_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			eth_txd3_pb8: eth_txd3_pb8 {
@@ -535,6 +555,11 @@
 			};
 
 			/* ETH_TX_CLK */
+
+			eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
 
 			eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -643,6 +668,18 @@
 
 			fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1429,6 +1466,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -1641,6 +1683,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -1740,6 +1788,11 @@
 				bias-pull-down;
 			};
 
+			spi2_miso_pc2: spi2_miso_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -1819,6 +1872,11 @@
 
 			spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2198,6 +2256,14 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			tim2_ch1_pa0: tim2_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
+			tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
 			tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -2336,6 +2402,18 @@
 
 			tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim5_ch1_pa0: tim5_ch1_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
+			tim15_ch1n_pa1: tim15_ch1n_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -2542,6 +2620,12 @@
 				drive-open-drain;
 			};
 
+			usart2_cts_pa0: usart2_cts_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -2618,6 +2702,12 @@
 
 			usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -2734,6 +2824,10 @@
 
 			usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
+			};
+
+			uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			uart4_rx_pa1: uart4_rx_pa1 {
@@ -2857,6 +2951,11 @@
 
 			usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
+				bias-pull-up;
+			};
+
+			uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3029,6 +3128,14 @@
 
 			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {


### PR DESCRIPTION
Update *-pinctrl.dtsi files using the latest version
of https://github.com/STMicroelectronics/STM32_open_pin_data
that reflect recent delivery of CubeMx 6.3.0

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>