### PR TITLE
stm32cube/wl: ll_utils: Consider HSEPRE when configuring PLL using HSE

### DIFF
--- a/stm32cube/stm32wlxx/README
+++ b/stm32cube/stm32wlxx/README
@@ -50,4 +50,9 @@ Patch List:
     Impacted files:
      drivers/include/stm32wlxx_hal_conf.h
 
+   *Take into account HSEPRE value when configuring HSE as PLL input
+    Impacted file:
+     stm32cube/stm32wlxx/drivers/src/stm32wlxx_ll_utils.c
+    ST Internal reference: 111260
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32wlxx/drivers/src/stm32wlxx_ll_utils.c
+++ b/stm32cube/stm32wlxx/drivers/src/stm32wlxx_ll_utils.c
@@ -581,7 +581,14 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(LL_UTILS_PLLInitTypeDef *UTILS_PLLInitS
   if (UTILS_PLL_IsBusy() == SUCCESS)
   {
     /* Calculate the new PLL output frequency */
-    pllrfreq = UTILS_GetPLLOutputFrequency(HSE_VALUE, UTILS_PLLInitStruct);
+    if (!LL_RCC_HSE_IsEnabledDiv2()) {
+      pllrfreq = UTILS_GetPLLOutputFrequency(HSE_VALUE, UTILS_PLLInitStruct);
+    }
+    else
+    {
+      /* HSE Pre is set */
+      pllrfreq = UTILS_GetPLLOutputFrequency(HSE_VALUE/2, UTILS_PLLInitStruct);
+    }
 
 #if defined(DUAL_CORE)
     hclk2freq = __LL_RCC_CALC_HCLK2_FREQ(pllrfreq, UTILS_ClkInitStruct->CPU2CLKDivider);


### PR DESCRIPTION
HSE prescaler value is not taken into account when computing
PLL frequency using HSE as input clock.
Fix this.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>