### PR TITLE
stm32cube: stm32f4: Remove unused variable

### DIFF
--- a/stm32cube/stm32f4xx/README
+++ b/stm32cube/stm32f4xx/README
@@ -52,4 +52,11 @@ Patch List:
     -Added stm32cube/stm32f4xx/drivers/include/stm32_assert.h
     -Removed unused stm32cube/stm32f4xx/drivers/include/stm32_assert_template.h
 
+   *Unused variable in HAL_QSPI_Command_IT
+    -removed tickstart variable declaration
+    Impacted files:
+     drivers/src/stm32f4xx_hal_qspi.c
+    ST Bug tracker ID: 112664
+
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32f4xx/drivers/src/stm32f4xx_hal_qspi.c
+++ b/stm32cube/stm32f4xx/drivers/src/stm32f4xx_hal_qspi.c
@@ -870,7 +870,6 @@ HAL_StatusTypeDef HAL_QSPI_Command(QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDe
 HAL_StatusTypeDef HAL_QSPI_Command_IT(QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDef *cmd)
 {
   HAL_StatusTypeDef status;
-  uint32_t tickstart = HAL_GetTick();
 
   /* Check the parameters */
   assert_param(IS_QSPI_INSTRUCTION_MODE(cmd->InstructionMode));


### PR DESCRIPTION
An unused variable was declared in HAL_QSPI_Command_IT.
Remove it.
An internal ST bug was created to fix this.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>