### PR TITLE
stm32cube: stm32h7: eth: avoid descriptor leak with enabled timestamping

### DIFF
--- a/stm32cube/stm32h7xx/README
+++ b/stm32cube/stm32h7xx/README
@@ -44,4 +44,8 @@ Patch List:
     -Added stm32cube/stm32h7xx/drivers/include/stm32_assert.h
     -Removed unused stm32cube/stm32h7xx/drivers/include/stm32_assert_template.h
 
+   *Fix context descriptor leak 
+    - Impacted file: stm32h7xx_hal_eth.c
+    - Internal reference: Not available. Will be fixed as part of a new eth hal implementation
+
    See release_note.html from STM32Cube


### PR DESCRIPTION
Ethernet HAL configures interrupts to be received upon filling every
RX descriptor. When timestamping is enabled, application needs to
process both normal and context descriptors, but there is a race
condition in HAL_ETH_IsRxDataAvailable() that might miss context
descriptor, effectively leaking it.

This change introduces spinlock to wait for context descriptor if
normal context indicates it will be available.

Signed-off-by: Alex Sergeev <asergeev@carbonrobotics.com>