### PR TITLE
stm32h7 adc driver oversampling ratio depends on ADC instance

### DIFF
--- a/stm32cube/stm32h7xx/README
+++ b/stm32cube/stm32h7xx/README
@@ -36,6 +36,12 @@ License Link:
 
 Patch List:
 
+   *LL_ADC_ConfigOverSamplingRatioShift
+    -ADC3 oversampling Ratio incorrectly set
+    Impacted files:
+     drivers/include/stm32h7xx_ll_adc.h
+    ST Bug tracker ID: 113809
+
    *Changes from official delivery:
     -dos2unix applied
     -trailing white spaces removed

--- a/stm32cube/stm32h7xx/drivers/include/stm32h7xx_ll_adc.h
+++ b/stm32cube/stm32h7xx/drivers/include/stm32h7xx_ll_adc.h
@@ -6238,10 +6238,22 @@ __STATIC_INLINE uint32_t LL_ADC_GetOverSamplingDiscont(ADC_TypeDef *ADCx)
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on either groups regular or injected.
+  * @note   Caution: Oversampling Ratio is dependent to ADC instance and IP version:
+  *         For STM32H72x/3x: ADC3 has 3-bit OVSR, and 9-bit OVSR for ADC1/ADC2
+  *         For Rest of STM32H7xxx All ADCs have 9-bit OVSR.
   * @rmtoll CFGR2    OVSS           LL_ADC_ConfigOverSamplingRatioShift\n
   *         CFGR2    OVSR           LL_ADC_ConfigOverSamplingRatioShift
   * @param  ADCx ADC instance
-  * @param  Ratio This parameter can be in the range from 1 to 1024.
+  * @param  Ratio This parameter can be in the range from 1 to 1024 or ...
+  *         one of the following values, in case of ADC3 of ADC_VER_V5_V90 :
+  *         @arg @ref LL_ADC_OVS_RATIO_2
+  *         @arg @ref LL_ADC_OVS_RATIO_4
+  *         @arg @ref LL_ADC_OVS_RATIO_8
+  *         @arg @ref LL_ADC_OVS_RATIO_16
+  *         @arg @ref LL_ADC_OVS_RATIO_32
+  *         @arg @ref LL_ADC_OVS_RATIO_64
+  *         @arg @ref LL_ADC_OVS_RATIO_128
+  *         @arg @ref LL_ADC_OVS_RATIO_256
   * @param  Shift This parameter can be one of the following values:
   *         @arg @ref LL_ADC_OVS_SHIFT_NONE
   *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_1
@@ -6259,19 +6271,48 @@ __STATIC_INLINE uint32_t LL_ADC_GetOverSamplingDiscont(ADC_TypeDef *ADCx)
   */
 __STATIC_INLINE void LL_ADC_ConfigOverSamplingRatioShift(ADC_TypeDef *ADCx, uint32_t Ratio, uint32_t Shift)
 {
-  MODIFY_REG(ADCx->CFGR2, (ADC_CFGR2_OVSS | ADC_CFGR2_OVSR), (Shift | (((Ratio - 1UL) << ADC_CFGR2_OVSR_Pos))));
+    /* ADC channels ratio shift oversampling */
+#if defined(ADC_VER_V5_V90)
+    if (ADCx == ADC3)
+    {
+        MODIFY_REG(ADCx->CFGR2, (ADC_CFGR2_OVSS | ADC3_CFGR2_OVSR), (Shift | Ratio));
+    } else
+#endif /* ADC_VER_V5_V90 */
+    {
+        MODIFY_REG(ADCx->CFGR2, (ADC_CFGR2_OVSS | ADC_CFGR2_OVSR), (Shift | (((Ratio - 1UL) << ADC_CFGR2_OVSR_Pos))));
+    }
 }
 
 /**
   * @brief  Get ADC oversampling ratio
   *        (impacting both ADC groups regular and injected)
+  * @note   Caution: Oversampling Ratio is dependent to ADC instance and IP version:
+  *         For STM32H72x/3x: ADC3 has 3-bit OVSR, and 9-bit OVSR for ADC1/ADC2
+  *         For Rest of STM32H7xxx All ADCs have 9-bit OVSR.
   * @rmtoll CFGR2    OVSR           LL_ADC_GetOverSamplingRatio
   * @param  ADCx ADC instance
-  * @retval Ratio This parameter can be in the from 1 to 1024.
+  * @retval Ratio This parameter can be a value from 1 to 1024 or ...
+  *         one of the following values, in case of ADC3 of ADC_VER_V5_V90 :
+  *         @arg @ref LL_ADC_OVS_RATIO_2
+  *         @arg @ref LL_ADC_OVS_RATIO_4
+  *         @arg @ref LL_ADC_OVS_RATIO_8
+  *         @arg @ref LL_ADC_OVS_RATIO_16
+  *         @arg @ref LL_ADC_OVS_RATIO_32
+  *         @arg @ref LL_ADC_OVS_RATIO_64
+  *         @arg @ref LL_ADC_OVS_RATIO_128
+  *         @arg @ref LL_ADC_OVS_RATIO_256
 */
 __STATIC_INLINE uint32_t LL_ADC_GetOverSamplingRatio(ADC_TypeDef *ADCx)
 {
-  return (((uint32_t)(READ_BIT(ADCx->CFGR2, ADC_CFGR2_OVSR)) + (1UL << ADC_CFGR2_OVSR_Pos)) >> ADC_CFGR2_OVSR_Pos);
+#if defined(ADC_VER_V5_V90)
+    if (ADCx == ADC3)
+    {
+        return (uint32_t)(READ_BIT(ADCx->CFGR2, ADC3_CFGR2_OVSR));
+    } else
+#endif /* ADC_VER_V5_V90 */
+    {
+        return (((uint32_t)(READ_BIT(ADCx->CFGR2, ADC_CFGR2_OVSR)) + (1UL << ADC_CFGR2_OVSR_Pos)) >> ADC_CFGR2_OVSR_Pos);
+    }
 }
 
 /**


### PR DESCRIPTION
Setting the Oversampling ratio with the
LL_ADC_ConfigOverSamplingRatioShift and LL_ADC_GetOverSamplingRatio functions must consider the ADC
instance and IP version. Some ADC have a 9-bit OVSR value
from 1 to 1024, other like ADC3 have 3-bit OVSR value.
Bit field position is also specific.

The ratio parameter is supposed to be a value from 1 to 1024 or [2, 4, 8, 16, 32, 64, 128, 256] for ADC3.
Which is not the same as in functions LL_ADC_ConfigOverSamplingRatioShift and LL_ADC_GetOverSamplingRatio for other series (which is LL_ADC_OVS_RATIO_xx)

required to fix https://github.com/zephyrproject-rtos/zephyr/issues/38606

Signed-off-by: Francois Ramu <francois.ramu@st.com>