### PR TITLE
stm32cube: u5: fix double promotion when calculating flash latency

### DIFF
--- a/stm32cube/stm32u5xx/drivers/src/stm32u5xx_ll_utils.c
+++ b/stm32cube/stm32u5xx/drivers/src/stm32u5xx_ll_utils.c
@@ -66,9 +66,9 @@
 #define UTILS_SCALE2_LATENCY1_FREQ    (50000000U)      /*!< HCLK frequency to set FLASH latency 1 in power scale 2 */
 #define UTILS_SCALE2_LATENCY2_FREQ    (75000000U)      /*!< HCLK frequency to set FLASH latency 2 in power scale 2 */
 #define UTILS_SCALE2_LATENCY3_FREQ    (100000000U)     /*!< HCLK frequency to set FLASH latency 3 in power scale 2 */
-#define UTILS_SCALE3_LATENCY0_FREQ    (12.5000000)    /*!< HCLK frequency to set FLASH latency 0 in power scale 3 */
+#define UTILS_SCALE3_LATENCY0_FREQ    (12.5000000f)    /*!< HCLK frequency to set FLASH latency 0 in power scale 3 */
 #define UTILS_SCALE3_LATENCY1_FREQ    (25000000U)      /*!< HCLK frequency to set FLASH latency 1 in power scale 3 */
-#define UTILS_SCALE3_LATENCY2_FREQ    (37.5000000)    /*!< HCLK frequency to set FLASH latency 2 in power scale 3 */
+#define UTILS_SCALE3_LATENCY2_FREQ    (37.5000000f)    /*!< HCLK frequency to set FLASH latency 2 in power scale 3 */
 #define UTILS_SCALE3_LATENCY3_FREQ    (50000000U)      /*!< HCLK frequency to set FLASH latency 3 in power scale 3 */
 #define UTILS_SCALE4_LATENCY0_FREQ    (8000000U)       /*!< HCLK frequency to set FLASH latency 0 in power scale 4 */
 #define UTILS_SCALE4_LATENCY1_FREQ    (16000000U)      /*!< HCLK frequency to set FLASH latency 1 in power scale 4 */
@@ -345,7 +345,7 @@ ErrorStatus LL_SetFlashLatency(uint32_t HCLK_Frequency)
     }
     else if (LL_PWR_GetRegulVoltageScaling() == LL_PWR_REGU_VOLTAGE_SCALE3)
     {
-      if ((float_t)HCLK_Frequency  <= UTILS_SCALE3_LATENCY0_FREQ)
+      if ((float)HCLK_Frequency <= UTILS_SCALE3_LATENCY0_FREQ)
       {
         /* 0 < HCLK <= 12.5 => 0WS (1 CPU cycles) : Do nothing, keep latency to default  LL_FLASH_LATENCY_0 */
       }
@@ -354,7 +354,7 @@ ErrorStatus LL_SetFlashLatency(uint32_t HCLK_Frequency)
         /* 12.5 < HCLK <= 25 => 1WS (2 CPU cycles) */
         latency = LL_FLASH_LATENCY_1;
       }
-      else if ((float_t)HCLK_Frequency <= UTILS_SCALE3_LATENCY2_FREQ)
+      else if ((float)HCLK_Frequency <= UTILS_SCALE3_LATENCY2_FREQ)
       {
         /* 25 < HCLK <= 37.5 => 2WS (3 CPU cycles) */
         latency = LL_FLASH_LATENCY_2;


### PR DESCRIPTION
The STM32U5 only has a single precision floating point processor. UTILS_SCALE3_LATENCY0_FREQ and UTILS_SCALE3_LATENCY2_FREQ were defined as double constants along with float_t mostly likely being a float. C implicit promotion rules will want to make floats into doubles very easily with the whole line getting promoted to doubles which can be inefficient.

Unless if I'm missing something here, I don't think it's a good idea to use `float_t` here. I've seen it used in other calculations in this module for performing a precise calculation where you'd want that level of control....but in this case all being done here is a comparison.

This is apart of trying to get `-Wdouble-promotion` added within Zephyr and these errors were discovered through an automated CI.

*I'm unsure of you're process over here for pull requests or issues, if there's an internal bug tracker you may want to add this to*

Zephyr Pull Request: https://github.com/zephyrproject-rtos/zephyr/pull/38958
CI Build Error (on 13/20): https://buildkite.com/zephyr/zephyr/builds/42989#d50e76fe-e820-499d-9f8e-ba160857de87