### PR TITLE
stm32cube: u5: correct the header file of the stm32_assert.h

### DIFF
--- a/stm32cube/stm32u5xx/drivers/include/stm32_assert.h
+++ b/stm32cube/stm32u5xx/drivers/include/stm32_assert.h
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier : Apache-2.0
-# Copyright (c) 2021 STMicroelectronics
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2021 STMicroelectronics
+ */
 
 #include <stm32u5xx_hal_conf.h>


### PR DESCRIPTION
The comment in the
modules/hal/stm32/stm32cube/stm32u5xx/drivers/include/stm32_assert.h
is not well formatted.

Signed-off-by: Francois Ramu <francois.ramu@st.com>