### PR TITLE
dts: provide octo-spi interface to stm32u5  stm32l5, stm32l4+ and stm32h7

### DIFF
--- a/dts/st/h7/stm32h723vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vehx-pinctrl.dtsi
@@ -1503,6 +1503,198 @@
 				pinmux = <STM32_PINMUX('E', 15, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vetx-pinctrl.dtsi
@@ -1503,6 +1503,198 @@
 				pinmux = <STM32_PINMUX('E', 15, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vghx-pinctrl.dtsi
@@ -1503,6 +1503,198 @@
 				pinmux = <STM32_PINMUX('E', 15, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
@@ -1503,6 +1503,198 @@
 				pinmux = <STM32_PINMUX('E', 15, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723zeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zeix-pinctrl.dtsi
@@ -2032,6 +2032,313 @@
 				pinmux = <STM32_PINMUX('G', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zetx-pinctrl.dtsi
@@ -2004,6 +2004,313 @@
 				pinmux = <STM32_PINMUX('G', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgix-pinctrl.dtsi
@@ -2032,6 +2032,313 @@
 				pinmux = <STM32_PINMUX('G', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
@@ -2004,6 +2004,313 @@
 				pinmux = <STM32_PINMUX('G', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725aeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725aeix-pinctrl.dtsi
@@ -2275,6 +2275,353 @@
 				pinmux = <STM32_PINMUX('H', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725agix-pinctrl.dtsi
@@ -2275,6 +2275,353 @@
 				pinmux = <STM32_PINMUX('H', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725iekx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725iekx-pinctrl.dtsi
@@ -2409,6 +2409,353 @@
 				pinmux = <STM32_PINMUX('H', 15, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725ietx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725ietx-pinctrl.dtsi
@@ -2060,6 +2060,313 @@
 				pinmux = <STM32_PINMUX('K', 2, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igkx-pinctrl.dtsi
@@ -2409,6 +2409,353 @@
 				pinmux = <STM32_PINMUX('H', 15, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igtx-pinctrl.dtsi
@@ -2060,6 +2060,313 @@
 				pinmux = <STM32_PINMUX('K', 2, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725revx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725revx-pinctrl.dtsi
@@ -747,6 +747,113 @@
 				pinmux = <STM32_PINMUX('D', 2, AF9)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
@@ -747,6 +747,113 @@
 				pinmux = <STM32_PINMUX('D', 2, AF9)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vehx-pinctrl.dtsi
@@ -1433,6 +1433,193 @@
 				pinmux = <STM32_PINMUX('E', 6, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vetx-pinctrl.dtsi
@@ -1337,6 +1337,173 @@
 				pinmux = <STM32_PINMUX('E', 5, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vghx-pinctrl.dtsi
@@ -1433,6 +1433,193 @@
 				pinmux = <STM32_PINMUX('E', 6, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
@@ -1337,6 +1337,173 @@
 				pinmux = <STM32_PINMUX('E', 5, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
@@ -1291,6 +1291,153 @@
 				pinmux = <STM32_PINMUX('E', 4, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zetx-pinctrl.dtsi
@@ -1802,6 +1802,263 @@
 				pinmux = <STM32_PINMUX('G', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
@@ -1802,6 +1802,263 @@
 				pinmux = <STM32_PINMUX('G', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730abixq-pinctrl.dtsi
@@ -2275,6 +2275,353 @@
 				pinmux = <STM32_PINMUX('H', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
@@ -2409,6 +2409,353 @@
 				pinmux = <STM32_PINMUX('H', 15, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
@@ -2060,6 +2060,313 @@
 				pinmux = <STM32_PINMUX('K', 2, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
@@ -1503,6 +1503,198 @@
 				pinmux = <STM32_PINMUX('E', 15, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
@@ -1503,6 +1503,198 @@
 				pinmux = <STM32_PINMUX('E', 15, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730zbix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbix-pinctrl.dtsi
@@ -2032,6 +2032,313 @@
 				pinmux = <STM32_PINMUX('G', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
@@ -2004,6 +2004,313 @@
 				pinmux = <STM32_PINMUX('G', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h733vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vghx-pinctrl.dtsi
@@ -1503,6 +1503,198 @@
 				pinmux = <STM32_PINMUX('E', 15, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
@@ -1503,6 +1503,198 @@
 				pinmux = <STM32_PINMUX('E', 15, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h733zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgix-pinctrl.dtsi
@@ -2032,6 +2032,313 @@
 				pinmux = <STM32_PINMUX('G', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
@@ -2004,6 +2004,313 @@
 				pinmux = <STM32_PINMUX('G', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735agix-pinctrl.dtsi
@@ -2275,6 +2275,353 @@
 				pinmux = <STM32_PINMUX('H', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igkx-pinctrl.dtsi
@@ -2409,6 +2409,353 @@
 				pinmux = <STM32_PINMUX('H', 15, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igtx-pinctrl.dtsi
@@ -2060,6 +2060,313 @@
 				pinmux = <STM32_PINMUX('K', 2, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
@@ -747,6 +747,113 @@
 				pinmux = <STM32_PINMUX('D', 2, AF9)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vghx-pinctrl.dtsi
@@ -1433,6 +1433,193 @@
 				pinmux = <STM32_PINMUX('E', 6, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
@@ -1337,6 +1337,173 @@
 				pinmux = <STM32_PINMUX('E', 5, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
@@ -1291,6 +1291,153 @@
 				pinmux = <STM32_PINMUX('E', 4, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
@@ -1802,6 +1802,263 @@
 				pinmux = <STM32_PINMUX('G', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa3: octospim_p1_io2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb12: octospim_p1_io0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pb13: octospim_p1_io2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -1842,6 +1842,333 @@
 				pinmux = <STM32_PINMUX('H', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -2031,6 +2031,318 @@
 				pinmux = <STM32_PINMUX('I', 11, AF9)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pi9: octospim_p2_io0_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pi10: octospim_p2_io1_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pi11: octospim_p2_io2_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -1950,6 +1950,333 @@
 				pinmux = <STM32_PINMUX('H', 15, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -2031,6 +2031,318 @@
 				pinmux = <STM32_PINMUX('I', 11, AF9)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pi9: octospim_p2_io0_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pi10: octospim_p2_io1_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pi11: octospim_p2_io2_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -1700,6 +1700,293 @@
 				pinmux = <STM32_PINMUX('K', 2, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -2351,6 +2351,393 @@
 				pinmux = <STM32_PINMUX('K', 7, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pi9: octospim_p2_io0_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pi10: octospim_p2_io1_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pi11: octospim_p2_io2_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pi12: octospim_p2_io3_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pi13: octospim_p2_clk_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pi14: octospim_p2_nclk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pj1: octospim_p2_io4_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pj2: octospim_p2_io5_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pk3: octospim_p2_io6_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pk4: octospim_p2_io7_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pk5: octospim_p2_ncs_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pk6: octospim_p2_dqs_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -2271,6 +2271,363 @@
 				pinmux = <STM32_PINMUX('K', 7, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pi9: octospim_p2_io0_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pi10: octospim_p2_io1_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pi11: octospim_p2_io2_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pi12: octospim_p2_io3_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pi13: octospim_p2_clk_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pi14: octospim_p2_nclk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pj1: octospim_p2_io4_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pj2: octospim_p2_io5_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pk3: octospim_p2_io6_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pk4: octospim_p2_io7_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pk5: octospim_p2_ncs_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pk6: octospim_p2_dqs_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
@@ -1358,6 +1358,198 @@
 				pinmux = <STM32_PINMUX('G', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
@@ -757,6 +757,113 @@
 				pinmux = <STM32_PINMUX('D', 2, AF9)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
@@ -1244,6 +1244,178 @@
 				pinmux = <STM32_PINMUX('E', 15, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
@@ -1174,6 +1174,173 @@
 				pinmux = <STM32_PINMUX('E', 6, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
@@ -1244,6 +1244,178 @@
 				pinmux = <STM32_PINMUX('E', 15, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
@@ -1092,6 +1092,153 @@
 				pinmux = <STM32_PINMUX('E', 5, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -1644,6 +1644,293 @@
 				pinmux = <STM32_PINMUX('G', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
@@ -1470,6 +1470,243 @@
 				pinmux = <STM32_PINMUX('G', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -1842,6 +1842,333 @@
 				pinmux = <STM32_PINMUX('H', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -1950,6 +1950,333 @@
 				pinmux = <STM32_PINMUX('H', 15, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -2031,6 +2031,318 @@
 				pinmux = <STM32_PINMUX('I', 11, AF9)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pi9: octospim_p2_io0_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pi10: octospim_p2_io1_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pi11: octospim_p2_io2_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
@@ -757,6 +757,113 @@
 				pinmux = <STM32_PINMUX('D', 2, AF9)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
@@ -1244,6 +1244,178 @@
 				pinmux = <STM32_PINMUX('E', 15, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -1644,6 +1644,293 @@
 				pinmux = <STM32_PINMUX('G', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -1842,6 +1842,333 @@
 				pinmux = <STM32_PINMUX('H', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -2031,6 +2031,318 @@
 				pinmux = <STM32_PINMUX('I', 11, AF9)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pi9: octospim_p2_io0_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pi10: octospim_p2_io1_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pi11: octospim_p2_io2_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -1950,6 +1950,333 @@
 				pinmux = <STM32_PINMUX('H', 15, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -2031,6 +2031,318 @@
 				pinmux = <STM32_PINMUX('I', 11, AF9)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pi9: octospim_p2_io0_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pi10: octospim_p2_io1_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pi11: octospim_p2_io2_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -1700,6 +1700,293 @@
 				pinmux = <STM32_PINMUX('K', 2, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -2351,6 +2351,393 @@
 				pinmux = <STM32_PINMUX('K', 7, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pi9: octospim_p2_io0_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pi10: octospim_p2_io1_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pi11: octospim_p2_io2_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pi12: octospim_p2_io3_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pi13: octospim_p2_clk_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pi14: octospim_p2_nclk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pj1: octospim_p2_io4_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pj2: octospim_p2_io5_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pk3: octospim_p2_io6_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pk4: octospim_p2_io7_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pk5: octospim_p2_ncs_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pk6: octospim_p2_dqs_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -2271,6 +2271,363 @@
 				pinmux = <STM32_PINMUX('K', 7, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_ph3: octospim_p1_io5_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pi9: octospim_p2_io0_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pi10: octospim_p2_io1_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pi11: octospim_p2_io2_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pi12: octospim_p2_io3_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pi13: octospim_p2_clk_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pi14: octospim_p2_nclk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pj1: octospim_p2_io4_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pj2: octospim_p2_io5_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pk3: octospim_p2_io6_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pk4: octospim_p2_io7_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pk5: octospim_p2_ncs_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pk6: octospim_p2_dqs_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
@@ -1358,6 +1358,198 @@
 				pinmux = <STM32_PINMUX('G', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
@@ -757,6 +757,113 @@
 				pinmux = <STM32_PINMUX('D', 2, AF9)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
@@ -1244,6 +1244,178 @@
 				pinmux = <STM32_PINMUX('E', 15, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
@@ -1174,6 +1174,173 @@
 				pinmux = <STM32_PINMUX('E', 6, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
@@ -1244,6 +1244,178 @@
 				pinmux = <STM32_PINMUX('E', 15, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
@@ -1092,6 +1092,153 @@
 				pinmux = <STM32_PINMUX('E', 5, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -1644,6 +1644,293 @@
 				pinmux = <STM32_PINMUX('G', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
@@ -1470,6 +1470,243 @@
 				pinmux = <STM32_PINMUX('G', 14, AF14)>;
 			};
 
+			/* OCTOSPI */
+
+			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pb2: octospim_p1_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb6: octospim_p1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pb10: octospim_p1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc9: octospim_p1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pc10: octospim_p1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pd11: octospim_p1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pd12: octospim_p1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pd13: octospim_p1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pe2: octospim_p1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io4_pe7: octospim_p1_io4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pe8: octospim_p1_io5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pe9: octospim_p1_io6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pe10: octospim_p1_io7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_ncs_pg6: octospim_p1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pg9: octospim_p1_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io6_pg10: octospim_p2_io6_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_io7_pg11: octospim_p2_io7_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io7_pg14: octospim_p1_io7_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
@@ -1486,6 +1486,383 @@
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_ph4: octospim_p2_dqs_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_ph6: octospim_p2_clk_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_ph7: octospim_p2_nclk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_ph8: octospim_p2_io3_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_ph9: octospim_p2_io4_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_ph10: octospim_p2_io5_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph11: octospim_p2_io6_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_ph12: octospim_p2_io7_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph15: octospim_p2_io6_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pi0: octospim_p1_io5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi5: octospim_p2_ncs_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pi6: octospim_p2_clk_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pi7: octospim_p2_nclk_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi8: octospim_p2_ncs_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pi9: octospim_p2_io2_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pi10: octospim_p2_io1_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pi11: octospim_p2_io0_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
@@ -1478,6 +1478,373 @@
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_ph4: octospim_p2_dqs_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_ph6: octospim_p2_clk_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_ph7: octospim_p2_nclk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_ph8: octospim_p2_io3_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_ph9: octospim_p2_io4_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_ph10: octospim_p2_io5_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_ph12: octospim_p2_io7_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph15: octospim_p2_io6_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pi0: octospim_p1_io5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi5: octospim_p2_ncs_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pi6: octospim_p2_clk_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pi7: octospim_p2_nclk_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi8: octospim_p2_ncs_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pi9: octospim_p2_io2_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pi10: octospim_p2_io1_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pi11: octospim_p2_io0_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
@@ -424,6 +424,108 @@
 				pinmux = <STM32_PINMUX('B', 11, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
@@ -424,6 +424,108 @@
 				pinmux = <STM32_PINMUX('B', 11, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
@@ -385,6 +385,103 @@
 				pinmux = <STM32_PINMUX('B', 7, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
@@ -385,6 +385,103 @@
 				pinmux = <STM32_PINMUX('B', 7, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
@@ -1349,6 +1349,288 @@
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
@@ -1309,6 +1309,283 @@
 				pinmux = <STM32_PINMUX('G', 13, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
@@ -570,6 +570,138 @@
 				pinmux = <STM32_PINMUX('C', 12, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
@@ -550,6 +550,138 @@
 				pinmux = <STM32_PINMUX('C', 12, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
@@ -1023,6 +1023,203 @@
 				pinmux = <STM32_PINMUX('E', 15, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
@@ -971,6 +971,218 @@
 				pinmux = <STM32_PINMUX('E', 15, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
@@ -989,6 +989,198 @@
 				pinmux = <STM32_PINMUX('E', 15, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
@@ -955,6 +955,218 @@
 				pinmux = <STM32_PINMUX('E', 15, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
@@ -1369,6 +1369,313 @@
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
@@ -1345,6 +1345,303 @@
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
@@ -1486,6 +1486,383 @@
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_ph4: octospim_p2_dqs_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_ph6: octospim_p2_clk_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_ph7: octospim_p2_nclk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_ph8: octospim_p2_io3_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_ph9: octospim_p2_io4_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_ph10: octospim_p2_io5_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph11: octospim_p2_io6_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_ph12: octospim_p2_io7_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph15: octospim_p2_io6_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pi0: octospim_p1_io5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi5: octospim_p2_ncs_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pi6: octospim_p2_clk_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pi7: octospim_p2_nclk_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi8: octospim_p2_ncs_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pi9: octospim_p2_io2_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pi10: octospim_p2_io1_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pi11: octospim_p2_io0_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agixp-pinctrl.dtsi
@@ -1478,6 +1478,373 @@
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_ph4: octospim_p2_dqs_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_ph6: octospim_p2_clk_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_ph7: octospim_p2_nclk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_ph8: octospim_p2_io3_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_ph9: octospim_p2_io4_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_ph10: octospim_p2_io5_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_ph12: octospim_p2_io7_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph15: octospim_p2_io6_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pi0: octospim_p1_io5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi5: octospim_p2_ncs_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pi6: octospim_p2_clk_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pi7: octospim_p2_nclk_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi8: octospim_p2_ncs_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pi9: octospim_p2_io2_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pi10: octospim_p2_io1_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pi11: octospim_p2_io0_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
@@ -424,6 +424,108 @@
 				pinmux = <STM32_PINMUX('B', 11, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4q5cgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgtxp-pinctrl.dtsi
@@ -385,6 +385,103 @@
 				pinmux = <STM32_PINMUX('B', 7, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
@@ -424,6 +424,108 @@
 				pinmux = <STM32_PINMUX('B', 11, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4q5cguxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cguxp-pinctrl.dtsi
@@ -385,6 +385,103 @@
 				pinmux = <STM32_PINMUX('B', 7, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
@@ -1349,6 +1349,288 @@
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgixp-pinctrl.dtsi
@@ -1309,6 +1309,283 @@
 				pinmux = <STM32_PINMUX('G', 13, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
@@ -570,6 +570,138 @@
 				pinmux = <STM32_PINMUX('C', 12, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtxp-pinctrl.dtsi
@@ -550,6 +550,138 @@
 				pinmux = <STM32_PINMUX('C', 12, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
@@ -1023,6 +1023,203 @@
 				pinmux = <STM32_PINMUX('E', 15, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtxp-pinctrl.dtsi
@@ -989,6 +989,198 @@
 				pinmux = <STM32_PINMUX('E', 15, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
@@ -971,6 +971,218 @@
 				pinmux = <STM32_PINMUX('E', 15, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyxp-pinctrl.dtsi
@@ -955,6 +955,218 @@
 				pinmux = <STM32_PINMUX('E', 15, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
@@ -1369,6 +1369,313 @@
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtxp-pinctrl.dtsi
@@ -1345,6 +1345,303 @@
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pb3: octospim_p1_io4_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pb4: octospim_p1_io5_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb5: octospim_p1_io0_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pb10: octospim_p1_io3_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb13: octospim_p1_io1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pb14: octospim_p1_io6_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pb15: octospim_p1_io7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pc4: octospim_p2_ncs_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
@@ -1200,6 +1200,308 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_ph4: octospim_p2_dqs_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_ph6: octospim_p2_clk_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_ph8: octospim_p2_io3_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_ph9: octospim_p2_io4_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_ph10: octospim_p2_io5_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph11: octospim_p2_io6_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_ph12: octospim_p2_io7_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph15: octospim_p2_io6_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pi0: octospim_p1_io5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi5: octospim_p2_ncs_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pi6: octospim_p2_clk_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi8: octospim_p2_ncs_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pi9: octospim_p2_io2_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pi10: octospim_p2_io1_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pi11: octospim_p2_io0_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
@@ -1063,6 +1063,223 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
@@ -769,6 +769,148 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
@@ -1083,6 +1083,248 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
@@ -1051,6 +1051,228 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
@@ -1063,6 +1063,238 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
@@ -1358,6 +1358,308 @@
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_ph4: octospim_p2_dqs_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_ph6: octospim_p2_clk_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_ph8: octospim_p2_io3_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_ph9: octospim_p2_io4_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_ph10: octospim_p2_io5_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph11: octospim_p2_io6_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_ph12: octospim_p2_io7_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph15: octospim_p2_io6_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pi0: octospim_p1_io5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi5: octospim_p2_ncs_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pi6: octospim_p2_clk_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi8: octospim_p2_ncs_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pi9: octospim_p2_io2_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pi10: octospim_p2_io1_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pi11: octospim_p2_io0_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
@@ -895,6 +895,148 @@
 				pinmux = <STM32_PINMUX('E', 15, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
@@ -1241,6 +1241,248 @@
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
@@ -1312,6 +1312,298 @@
 				pinmux = <STM32_PINMUX('G', 13, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_ph4: octospim_p2_dqs_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_ph8: octospim_p2_io3_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_ph9: octospim_p2_io4_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_ph10: octospim_p2_io5_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph11: octospim_p2_io6_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_ph12: octospim_p2_io7_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph15: octospim_p2_io6_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pi0: octospim_p1_io5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi5: octospim_p2_ncs_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pi6: octospim_p2_clk_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pi9: octospim_p2_io2_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pi10: octospim_p2_io1_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pi11: octospim_p2_io0_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
@@ -803,6 +803,148 @@
 				pinmux = <STM32_PINMUX('E', 15, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
@@ -1213,6 +1213,238 @@
 				pinmux = <STM32_PINMUX('G', 13, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
@@ -1185,6 +1185,238 @@
 				pinmux = <STM32_PINMUX('G', 6, AF9)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
@@ -1205,6 +1205,228 @@
 				pinmux = <STM32_PINMUX('G', 13, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
@@ -1169,6 +1169,223 @@
 				pinmux = <STM32_PINMUX('G', 6, AF9)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
@@ -1200,6 +1200,308 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_ph4: octospim_p2_dqs_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_ph6: octospim_p2_clk_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_ph8: octospim_p2_io3_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_ph9: octospim_p2_io4_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_ph10: octospim_p2_io5_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph11: octospim_p2_io6_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_ph12: octospim_p2_io7_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph15: octospim_p2_io6_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pi0: octospim_p1_io5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi5: octospim_p2_ncs_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pi6: octospim_p2_clk_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi8: octospim_p2_ncs_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pi9: octospim_p2_io2_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pi10: octospim_p2_io1_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pi11: octospim_p2_io0_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
@@ -1063,6 +1063,223 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
@@ -769,6 +769,148 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
@@ -1083,6 +1083,248 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
@@ -1051,6 +1051,228 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
@@ -1358,6 +1358,308 @@
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_ph4: octospim_p2_dqs_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_ph6: octospim_p2_clk_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_ph8: octospim_p2_io3_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_ph9: octospim_p2_io4_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_ph10: octospim_p2_io5_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph11: octospim_p2_io6_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_ph12: octospim_p2_io7_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph15: octospim_p2_io6_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pi0: octospim_p1_io5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi5: octospim_p2_ncs_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pi6: octospim_p2_clk_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi8: octospim_p2_ncs_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pi9: octospim_p2_io2_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pi10: octospim_p2_io1_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pi11: octospim_p2_io0_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
@@ -895,6 +895,148 @@
 				pinmux = <STM32_PINMUX('E', 15, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
@@ -1241,6 +1241,248 @@
 				pinmux = <STM32_PINMUX('G', 14, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
@@ -1312,6 +1312,298 @@
 				pinmux = <STM32_PINMUX('G', 13, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_ph4: octospim_p2_dqs_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_ph8: octospim_p2_io3_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_ph9: octospim_p2_io4_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_ph10: octospim_p2_io5_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph11: octospim_p2_io6_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_ph12: octospim_p2_io7_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph15: octospim_p2_io6_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pi0: octospim_p1_io5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi5: octospim_p2_ncs_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pi6: octospim_p2_clk_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pi9: octospim_p2_io2_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pi10: octospim_p2_io1_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pi11: octospim_p2_io0_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
@@ -803,6 +803,148 @@
 				pinmux = <STM32_PINMUX('E', 15, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
@@ -1213,6 +1213,238 @@
 				pinmux = <STM32_PINMUX('G', 13, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
@@ -1185,6 +1185,238 @@
 				pinmux = <STM32_PINMUX('G', 6, AF9)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
@@ -1205,6 +1205,228 @@
 				pinmux = <STM32_PINMUX('G', 13, AF11)>;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
@@ -364,6 +364,73 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
@@ -364,6 +364,73 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
@@ -334,6 +334,68 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
@@ -334,6 +334,68 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
@@ -520,6 +520,123 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc4: octospi1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pe13: octospi1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pe14: octospi1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pe15: octospi1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pg11: octospi1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
@@ -508,6 +508,108 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc4: octospi1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pg11: octospi1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
@@ -1078,6 +1078,173 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc4: octospi1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pd4: octospi1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pd5: octospi1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pd6: octospi1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pd7: octospi1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pe3: octospi1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pe9: octospi1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pe10: octospi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pe11: octospi1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pe12: octospi1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pe13: octospi1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pe14: octospi1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pe15: octospi1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pf11: octospi1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pg6: octospi1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeix-pinctrl.dtsi
@@ -1118,6 +1118,178 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc4: octospi1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pd4: octospi1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pd5: octospi1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pd6: octospi1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pd7: octospi1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pe3: octospi1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pe9: octospi1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pe10: octospi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pe11: octospi1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pe12: octospi1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pe13: octospi1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pe14: octospi1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pe15: octospi1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pf11: octospi1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pg6: octospi1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pg11: octospi1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
@@ -1110,6 +1110,173 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc4: octospi1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pd4: octospi1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pd5: octospi1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pd6: octospi1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pd7: octospi1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pe3: octospi1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pe9: octospi1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pe10: octospi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pe11: octospi1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pe12: octospi1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pe13: octospi1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pe14: octospi1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pe15: octospi1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pf11: octospi1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pg6: octospi1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
@@ -480,6 +480,103 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc4: octospi1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxp-pinctrl.dtsi
@@ -464,6 +464,103 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc4: octospi1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l5/stm32l552retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxq-pinctrl.dtsi
@@ -422,6 +422,88 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
@@ -786,6 +786,153 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pd4: octospi1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pd5: octospi1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pd6: octospi1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pd7: octospi1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pe3: octospi1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pe9: octospi1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pe10: octospi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pe11: octospi1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pe12: octospi1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pe13: octospi1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pe14: octospi1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pe15: octospi1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552vetx-pinctrl.dtsi
@@ -824,6 +824,163 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc4: octospi1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pd4: octospi1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pd5: octospi1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pd6: octospi1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pd7: octospi1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pe3: octospi1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pe9: octospi1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pe10: octospi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pe11: octospi1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pe12: octospi1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pe13: octospi1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pe14: octospi1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pe15: octospi1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
@@ -1106,6 +1106,188 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pd4: octospi1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pd5: octospi1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pd6: octospi1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pd7: octospi1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pe3: octospi1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pe9: octospi1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pe10: octospi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pe11: octospi1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pe12: octospi1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pe13: octospi1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pe14: octospi1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pe15: octospi1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pf6: octospi1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pf7: octospi1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pf8: octospi1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pf9: octospi1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pf10: octospi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pf11: octospi1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pg6: octospi1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l552zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552zetx-pinctrl.dtsi
@@ -1138,6 +1138,203 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc4: octospi1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pd4: octospi1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pd5: octospi1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pd6: octospi1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pd7: octospi1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pe3: octospi1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pe9: octospi1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pe10: octospi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pe11: octospi1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pe12: octospi1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pe13: octospi1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pe14: octospi1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pe15: octospi1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pf6: octospi1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pf7: octospi1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pf8: octospi1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pf9: octospi1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pf10: octospi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pf11: octospi1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pg6: octospi1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pg11: octospi1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562cetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetx-pinctrl.dtsi
@@ -364,6 +364,73 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
@@ -334,6 +334,68 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l5/stm32l562ceux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceux-pinctrl.dtsi
@@ -364,6 +364,73 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
@@ -334,6 +334,68 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
@@ -520,6 +520,123 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc4: octospi1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pe13: octospi1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pe14: octospi1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pe15: octospi1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pg11: octospi1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
@@ -508,6 +508,108 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc4: octospi1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pg11: octospi1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeix-pinctrl.dtsi
@@ -1118,6 +1118,178 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc4: octospi1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pd4: octospi1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pd5: octospi1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pd6: octospi1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pd7: octospi1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pe3: octospi1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pe9: octospi1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pe10: octospi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pe11: octospi1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pe12: octospi1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pe13: octospi1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pe14: octospi1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pe15: octospi1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pf11: octospi1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pg6: octospi1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pg11: octospi1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
@@ -1110,6 +1110,173 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc4: octospi1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pd4: octospi1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pd5: octospi1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pd6: octospi1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pd7: octospi1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pe3: octospi1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pe9: octospi1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pe10: octospi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pe11: octospi1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pe12: octospi1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pe13: octospi1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pe14: octospi1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pe15: octospi1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pf11: octospi1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pg6: octospi1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
@@ -1078,6 +1078,173 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc4: octospi1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pd4: octospi1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pd5: octospi1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pd6: octospi1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pd7: octospi1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pe3: octospi1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pe9: octospi1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pe10: octospi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pe11: octospi1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pe12: octospi1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pe13: octospi1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pe14: octospi1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pe15: octospi1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pf11: octospi1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pg6: octospi1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562retx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retx-pinctrl.dtsi
@@ -480,6 +480,103 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc4: octospi1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxp-pinctrl.dtsi
@@ -464,6 +464,103 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc4: octospi1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l5/stm32l562retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxq-pinctrl.dtsi
@@ -422,6 +422,88 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetx-pinctrl.dtsi
@@ -824,6 +824,163 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc4: octospi1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pd4: octospi1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pd5: octospi1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pd6: octospi1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pd7: octospi1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pe3: octospi1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pe9: octospi1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pe10: octospi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pe11: octospi1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pe12: octospi1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pe13: octospi1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pe14: octospi1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pe15: octospi1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
@@ -786,6 +786,153 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pd4: octospi1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pd5: octospi1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pd6: octospi1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pd7: octospi1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pe3: octospi1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pe9: octospi1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pe10: octospi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pe11: octospi1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pe12: octospi1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pe13: octospi1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pe14: octospi1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pe15: octospi1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetx-pinctrl.dtsi
@@ -1138,6 +1138,203 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb12: octospi1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc4: octospi1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pd4: octospi1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pd5: octospi1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pd6: octospi1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pd7: octospi1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pe3: octospi1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pe9: octospi1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pe10: octospi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pe11: octospi1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pe12: octospi1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pe13: octospi1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pe14: octospi1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pe15: octospi1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pf6: octospi1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pf7: octospi1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pf8: octospi1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pf9: octospi1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pf10: octospi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pf11: octospi1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pg6: octospi1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pg11: octospi1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
@@ -1106,6 +1106,188 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospi1_dqs_pa1: octospi1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa2: octospi1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pa3: octospi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pa4: octospi1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pa6: octospi1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pa7: octospi1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pb0: octospi1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pb1: octospi1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pb2: octospi1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pb5: octospi1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pb10: octospi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pb11: octospi1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pc0: octospi1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pc1: octospi1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pc2: octospi1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pc3: octospi1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pc11: octospi1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io4_pd4: octospi1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io5_pd5: octospi1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io6_pd6: octospi1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io7_pd7: octospi1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pe3: octospi1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pe9: octospi1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pe10: octospi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_ncs_pe11: octospi1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pe12: octospi1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pe13: octospi1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pe14: octospi1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pe15: octospi1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io3_pf6: octospi1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io2_pf7: octospi1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io0_pf8: octospi1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_io1_pf9: octospi1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_clk_pf10: octospi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_nclk_pf11: octospi1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospi1_dqs_pg6: octospi1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575agix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575agix-pinctrl.dtsi
@@ -1290,6 +1290,378 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pf6: octospim_p2_ncs_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_ph4: octospim_p2_dqs_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_ph6: octospim_p2_clk_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_ph7: octospim_p2_nclk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_ph8: octospim_p2_io3_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_ph9: octospim_p2_io4_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_ph10: octospim_p2_io5_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph11: octospim_p2_io6_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_ph12: octospim_p2_io7_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph15: octospim_p2_io6_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pi0: octospim_p1_io5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pi1: octospim_p2_io2_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pi2: octospim_p2_io1_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pi3: octospim_p2_io0_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi5: octospim_p2_ncs_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pi6: octospim_p2_clk_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pi7: octospim_p2_nclk_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575agixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575agixq-pinctrl.dtsi
@@ -1254,6 +1254,373 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pf6: octospim_p2_ncs_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_ph4: octospim_p2_dqs_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_ph6: octospim_p2_clk_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_ph7: octospim_p2_nclk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_ph8: octospim_p2_io3_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_ph9: octospim_p2_io4_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_ph10: octospim_p2_io5_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph11: octospim_p2_io6_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_ph12: octospim_p2_io7_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph15: octospim_p2_io6_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pi0: octospim_p1_io5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pi1: octospim_p2_io2_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pi2: octospim_p2_io1_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pi3: octospim_p2_io0_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi5: octospim_p2_ncs_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pi6: octospim_p2_clk_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pi7: octospim_p2_nclk_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575aiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575aiix-pinctrl.dtsi
@@ -1290,6 +1290,378 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pf6: octospim_p2_ncs_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_ph4: octospim_p2_dqs_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_ph6: octospim_p2_clk_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_ph7: octospim_p2_nclk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_ph8: octospim_p2_io3_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_ph9: octospim_p2_io4_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_ph10: octospim_p2_io5_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph11: octospim_p2_io6_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_ph12: octospim_p2_io7_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph15: octospim_p2_io6_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pi0: octospim_p1_io5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pi1: octospim_p2_io2_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pi2: octospim_p2_io1_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pi3: octospim_p2_io0_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi5: octospim_p2_ncs_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pi6: octospim_p2_clk_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pi7: octospim_p2_nclk_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575aiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575aiixq-pinctrl.dtsi
@@ -1254,6 +1254,373 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pf6: octospim_p2_ncs_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_ph4: octospim_p2_dqs_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_ph6: octospim_p2_clk_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_ph7: octospim_p2_nclk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_ph8: octospim_p2_io3_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_ph9: octospim_p2_io4_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_ph10: octospim_p2_io5_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph11: octospim_p2_io6_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_ph12: octospim_p2_io7_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph15: octospim_p2_io6_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pi0: octospim_p1_io5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pi1: octospim_p2_io2_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pi2: octospim_p2_io1_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pi3: octospim_p2_io0_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi5: octospim_p2_ncs_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pi6: octospim_p2_clk_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pi7: octospim_p2_nclk_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575cgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgtx-pinctrl.dtsi
@@ -342,6 +342,78 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u575cgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgtxq-pinctrl.dtsi
@@ -300,6 +300,63 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u575cgux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgux-pinctrl.dtsi
@@ -342,6 +342,78 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u575cguxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cguxq-pinctrl.dtsi
@@ -300,6 +300,63 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u575citx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575citx-pinctrl.dtsi
@@ -342,6 +342,78 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u575citxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575citxq-pinctrl.dtsi
@@ -300,6 +300,63 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u575ciux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ciux-pinctrl.dtsi
@@ -342,6 +342,78 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u575ciuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ciuxq-pinctrl.dtsi
@@ -300,6 +300,63 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u575ogyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ogyxq-pinctrl.dtsi
@@ -676,6 +676,143 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575oiyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575oiyxq-pinctrl.dtsi
@@ -676,6 +676,143 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575qgix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qgix-pinctrl.dtsi
@@ -1146,6 +1146,263 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575qgixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qgixq-pinctrl.dtsi
@@ -1106,6 +1106,253 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575qiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qiix-pinctrl.dtsi
@@ -1146,6 +1146,263 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qiixq-pinctrl.dtsi
@@ -1106,6 +1106,253 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575rgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575rgtx-pinctrl.dtsi
@@ -458,6 +458,108 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575rgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575rgtxq-pinctrl.dtsi
@@ -416,6 +416,98 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575ritx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ritx-pinctrl.dtsi
@@ -458,6 +458,108 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575ritxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ritxq-pinctrl.dtsi
@@ -416,6 +416,98 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575vgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vgtx-pinctrl.dtsi
@@ -820,6 +820,173 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575vgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vgtxq-pinctrl.dtsi
@@ -798,6 +798,168 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vitx-pinctrl.dtsi
@@ -820,6 +820,173 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vitxq-pinctrl.dtsi
@@ -798,6 +798,168 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575zgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zgtx-pinctrl.dtsi
@@ -1158,6 +1158,288 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pf6: octospim_p2_ncs_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575zgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zgtxq-pinctrl.dtsi
@@ -1142,6 +1142,278 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pf6: octospim_p2_ncs_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575zitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zitx-pinctrl.dtsi
@@ -1158,6 +1158,288 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pf6: octospim_p2_ncs_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u575zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zitxq-pinctrl.dtsi
@@ -1142,6 +1142,278 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pf6: octospim_p2_ncs_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u585aiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585aiix-pinctrl.dtsi
@@ -1290,6 +1290,378 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pf6: octospim_p2_ncs_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_ph4: octospim_p2_dqs_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_ph6: octospim_p2_clk_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_ph7: octospim_p2_nclk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_ph8: octospim_p2_io3_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_ph9: octospim_p2_io4_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_ph10: octospim_p2_io5_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph11: octospim_p2_io6_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_ph12: octospim_p2_io7_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph15: octospim_p2_io6_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pi0: octospim_p1_io5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pi1: octospim_p2_io2_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pi2: octospim_p2_io1_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pi3: octospim_p2_io0_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi5: octospim_p2_ncs_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pi6: octospim_p2_clk_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pi7: octospim_p2_nclk_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u585aiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585aiixq-pinctrl.dtsi
@@ -1254,6 +1254,373 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pf6: octospim_p2_ncs_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_ph2: octospim_p1_io4_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_ph4: octospim_p2_dqs_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_ph6: octospim_p2_clk_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_ph7: octospim_p2_nclk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_ph8: octospim_p2_io3_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_ph9: octospim_p2_io4_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_ph10: octospim_p2_io5_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph11: octospim_p2_io6_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_ph12: octospim_p2_io7_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_ph15: octospim_p2_io6_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pi0: octospim_p1_io5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pi1: octospim_p2_io2_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pi2: octospim_p2_io1_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pi3: octospim_p2_io0_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pi5: octospim_p2_ncs_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pi6: octospim_p2_clk_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pi7: octospim_p2_nclk_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u585citx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585citx-pinctrl.dtsi
@@ -342,6 +342,78 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u585citxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585citxq-pinctrl.dtsi
@@ -300,6 +300,63 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u585ciux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ciux-pinctrl.dtsi
@@ -342,6 +342,78 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u585ciuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ciuxq-pinctrl.dtsi
@@ -300,6 +300,63 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/u5/stm32u585oiyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585oiyxq-pinctrl.dtsi
@@ -676,6 +676,143 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u585qiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585qiix-pinctrl.dtsi
@@ -1146,6 +1146,263 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u585ritx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ritx-pinctrl.dtsi
@@ -458,6 +458,108 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u585ritxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ritxq-pinctrl.dtsi
@@ -416,6 +416,98 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u585vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585vitx-pinctrl.dtsi
@@ -820,6 +820,173 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u585vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585vitxq-pinctrl.dtsi
@@ -798,6 +798,168 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pb11: octospim_p1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/u5/stm32u585zitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585zitx-pinctrl.dtsi
@@ -1158,6 +1158,288 @@
 				drive-open-drain;
 			};
 
+			/* OCTOSPI */
+
+			octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa2: octospim_p1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pa4: octospim_p1_ncs_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pa6: octospim_p1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pa7: octospim_p1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pa12: octospim_p2_ncs_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pb0: octospim_p1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pb1: octospim_p1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pb2: octospim_p1_dqs_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb5: octospim_p1_nclk_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pb10: octospim_p1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pb12: octospim_p1_nclk_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc0: octospim_p1_io7_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pc1: octospim_p1_io4_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pc4: octospim_p1_io7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pc11: octospim_p1_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pd3: octospim_p2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io4_pd4: octospim_p1_io4_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pd5: octospim_p1_io5_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io6_pd6: octospim_p1_io6_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io7_pd7: octospim_p1_io7_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pe3: octospim_p1_dqs_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pe9: octospim_p1_nclk_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pe10: octospim_p1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_ncs_pe11: octospim_p1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pe12: octospim_p1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pe13: octospim_p1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pe14: octospim_p1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pe15: octospim_p1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io0_pf0: octospim_p2_io0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io1_pf1: octospim_p2_io1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io2_pf2: octospim_p2_io2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io3_pf3: octospim_p2_io3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_clk_pf4: octospim_p2_clk_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_nclk_pf5: octospim_p2_nclk_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io3_pf6: octospim_p1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pf6: octospim_p2_ncs_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io2_pf7: octospim_p1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io0_pf8: octospim_p1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io1_pf9: octospim_p1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_clk_pf10: octospim_p1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_nclk_pf11: octospim_p1_nclk_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pf12: octospim_p2_dqs_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io4_pg0: octospim_p2_io4_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io5_pg1: octospim_p2_io5_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_dqs_pg6: octospim_p1_dqs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg7: octospim_p2_dqs_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io6_pg9: octospim_p2_io6_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_io7_pg10: octospim_p2_io7_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p1_io5_pg11: octospim_p1_io5_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_ncs_pg12: octospim_p2_ncs_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			octospim_p2_dqs_pg15: octospim_p2_dqs_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -178,6 +178,10 @@
 - name: LTDC
   match: "^LTDC_(?:DE|CLK|HSYNC|VSYNC|R[0-7]|G[0-7]|B[0-7])$"
 
+- name: OCTOSPI
+  match: "^OCTOSPI(.*)(?:CLK|NCS|DQS|IO[0-7])$"
+  slew-rate: very-high-speed
+
 - name: QUADSPI
   match: "^QUADSPI(\\d+)?_(?:CLK|NCS|BK1_NCS|BK1_IO[0-3]|BK2_NCS|BK2_IO[0-3])$"
   slew-rate: very-high-speed


### PR DESCRIPTION
configure the octospi pin definition for the stm32u5xx and stm32l5x2 devices in the stm32CUBE
configure the octospi pin definition for the stm32l4plus and stm32h7 devices in the stm32CUBE

required by the flash_stm32_ospi.c driver https://github.com/zephyrproject-rtos/zephyr/pull/39770

Signed-off-by: Francois Ramu francois.ramu@st.com