### PR TITLE
dts/st/f1: Review remap field generation

### DIFF
--- a/dts/st/f1/stm32f100c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100c(4-6)tx-pinctrl.dtsi
@@ -65,275 +65,275 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM15_REMAP0)>;
 			};
 
 			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
 			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
 			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
@@ -341,11 +341,11 @@
 			};
 
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
@@ -353,11 +353,11 @@
 			};
 
 			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
 			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
@@ -365,7 +365,7 @@
 			};
 
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM17_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -377,7 +377,7 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -389,35 +389,35 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f100c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100c(8-b)tx-pinctrl.dtsi
@@ -65,12 +65,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -82,12 +82,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -99,12 +99,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -116,11 +116,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -130,11 +130,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -144,11 +144,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -158,11 +158,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -172,11 +172,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -186,12 +186,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -203,11 +203,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -217,183 +217,183 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM15_REMAP0)>;
 			};
 
 			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
 			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
 			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
@@ -401,11 +401,11 @@
 			};
 
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
@@ -413,11 +413,11 @@
 			};
 
 			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
 			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
@@ -425,7 +425,7 @@
 			};
 
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM17_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -437,19 +437,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -461,51 +461,51 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f100r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(4-6)hx-pinctrl.dtsi
@@ -85,291 +85,291 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM15_REMAP0)>;
 			};
 
 			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
 			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
 			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
@@ -377,11 +377,11 @@
 			};
 
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
@@ -389,11 +389,11 @@
 			};
 
 			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
 			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
@@ -401,7 +401,7 @@
 			};
 
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM17_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -413,7 +413,7 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -425,35 +425,35 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f100r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(4-6)tx-pinctrl.dtsi
@@ -89,291 +89,291 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM15_REMAP0)>;
 			};
 
 			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
 			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
 			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
@@ -381,11 +381,11 @@
 			};
 
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
@@ -393,11 +393,11 @@
 			};
 
 			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
 			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
@@ -405,7 +405,7 @@
 			};
 
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM17_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -417,7 +417,7 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -429,35 +429,35 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f100r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(8-b)hx-pinctrl.dtsi
@@ -85,12 +85,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -102,12 +102,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -119,12 +119,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -136,11 +136,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -150,11 +150,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -164,11 +164,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -178,11 +178,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -192,11 +192,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -206,12 +206,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -223,11 +223,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -237,199 +237,199 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM15_REMAP0)>;
 			};
 
 			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
 			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
 			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
@@ -437,11 +437,11 @@
 			};
 
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
@@ -449,11 +449,11 @@
 			};
 
 			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
 			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
@@ -461,7 +461,7 @@
 			};
 
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM17_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -473,19 +473,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -497,59 +497,59 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f100r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(8-b)tx-pinctrl.dtsi
@@ -89,12 +89,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -106,12 +106,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -123,12 +123,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -140,11 +140,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -154,11 +154,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -168,11 +168,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -182,11 +182,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -196,11 +196,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -210,12 +210,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -227,11 +227,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -241,199 +241,199 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM15_REMAP0)>;
 			};
 
 			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
 			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
 			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
@@ -441,11 +441,11 @@
 			};
 
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
@@ -453,11 +453,11 @@
 			};
 
 			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
 			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
@@ -465,7 +465,7 @@
 			};
 
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM17_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -477,19 +477,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -501,59 +501,59 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f100r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(c-d-e)tx-pinctrl.dtsi
@@ -89,12 +89,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -106,12 +106,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -123,12 +123,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -145,11 +145,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -163,11 +163,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -181,11 +181,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -199,11 +199,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -217,11 +217,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -235,12 +235,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -257,11 +257,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -275,219 +275,219 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim12_ch1_pwm_pb12: tim12_ch1_pwm_pb12 {
-				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, TIM12_REMAP1)>;
 			};
 
 			tim12_ch2_pwm_pb13: tim12_ch2_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM12_REMAP1)>;
 			};
 
 			tim12_ch1_pwm_pc4: tim12_ch1_pwm_pc4 {
-				pinmux = <STM32F1_PINMUX('C', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('C', 4, ALTERNATE, TIM12_REMAP0)>;
 			};
 
 			tim12_ch2_pwm_pc5: tim12_ch2_pwm_pc5 {
-				pinmux = <STM32F1_PINMUX('C', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('C', 5, ALTERNATE, TIM12_REMAP0)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim13_ch1_pwm_pb0: tim13_ch1_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM13_REMAP1)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim13_ch1_pwm_pc8: tim13_ch1_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM13_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM14_REMAP1)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim14_ch1_pwm_pc9: tim14_ch1_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM14_REMAP0)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -499,7 +499,7 @@
 			};
 
 			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM15_REMAP0)>;
 			};
 
 			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
@@ -507,7 +507,7 @@
 			};
 
 			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
 			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
@@ -515,7 +515,7 @@
 			};
 
 			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
 			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
@@ -523,11 +523,11 @@
 			};
 
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
@@ -535,11 +535,11 @@
 			};
 
 			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
 			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
@@ -547,7 +547,7 @@
 			};
 
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM17_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -559,19 +559,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -583,37 +583,37 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -627,23 +627,23 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f100v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100v(8-b)tx-pinctrl.dtsi
@@ -89,12 +89,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -106,12 +106,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -123,12 +123,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -140,11 +140,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -154,11 +154,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -168,11 +168,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -182,11 +182,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -196,11 +196,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -210,12 +210,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -227,11 +227,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -241,243 +241,243 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
-				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
-				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
-				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
-				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
-				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
-				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
-				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM15_REMAP0)>;
 			};
 
 			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
 			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
 			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
@@ -485,11 +485,11 @@
 			};
 
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
@@ -497,11 +497,11 @@
 			};
 
 			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
 			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
@@ -509,7 +509,7 @@
 			};
 
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM17_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -521,31 +521,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -557,83 +557,83 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f100v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100v(c-d-e)tx-pinctrl.dtsi
@@ -89,12 +89,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -106,12 +106,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -123,12 +123,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -145,11 +145,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -163,11 +163,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -181,11 +181,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -199,11 +199,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -217,11 +217,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -235,12 +235,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -257,11 +257,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -275,263 +275,263 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
-				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
-				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
-				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
-				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
-				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
-				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
-				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim12_ch1_pwm_pb12: tim12_ch1_pwm_pb12 {
-				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, TIM12_REMAP1)>;
 			};
 
 			tim12_ch2_pwm_pb13: tim12_ch2_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM12_REMAP1)>;
 			};
 
 			tim12_ch1_pwm_pc4: tim12_ch1_pwm_pc4 {
-				pinmux = <STM32F1_PINMUX('C', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('C', 4, ALTERNATE, TIM12_REMAP0)>;
 			};
 
 			tim12_ch2_pwm_pc5: tim12_ch2_pwm_pc5 {
-				pinmux = <STM32F1_PINMUX('C', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('C', 5, ALTERNATE, TIM12_REMAP0)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim13_ch1_pwm_pb0: tim13_ch1_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM13_REMAP1)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim13_ch1_pwm_pc8: tim13_ch1_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM13_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM14_REMAP1)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim14_ch1_pwm_pc9: tim14_ch1_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM14_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -543,7 +543,7 @@
 			};
 
 			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM15_REMAP0)>;
 			};
 
 			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
@@ -551,7 +551,7 @@
 			};
 
 			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
 			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
@@ -559,7 +559,7 @@
 			};
 
 			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
 			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
@@ -567,11 +567,11 @@
 			};
 
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
@@ -579,11 +579,11 @@
 			};
 
 			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
 			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
@@ -591,7 +591,7 @@
 			};
 
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM17_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -603,31 +603,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -639,53 +639,53 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -699,31 +699,31 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f100z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100z(c-d-e)tx-pinctrl.dtsi
@@ -89,12 +89,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -106,12 +106,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -123,12 +123,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -145,11 +145,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -163,11 +163,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -181,11 +181,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -199,11 +199,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -217,11 +217,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -235,12 +235,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -257,11 +257,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -275,263 +275,263 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
-				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
-				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
-				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
-				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
-				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
-				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
-				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim12_ch1_pwm_pb12: tim12_ch1_pwm_pb12 {
-				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, TIM12_REMAP1)>;
 			};
 
 			tim12_ch2_pwm_pb13: tim12_ch2_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM12_REMAP1)>;
 			};
 
 			tim12_ch1_pwm_pc4: tim12_ch1_pwm_pc4 {
-				pinmux = <STM32F1_PINMUX('C', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('C', 4, ALTERNATE, TIM12_REMAP0)>;
 			};
 
 			tim12_ch2_pwm_pc5: tim12_ch2_pwm_pc5 {
-				pinmux = <STM32F1_PINMUX('C', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('C', 5, ALTERNATE, TIM12_REMAP0)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim13_ch1_pwm_pb0: tim13_ch1_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM13_REMAP1)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim13_ch1_pwm_pc8: tim13_ch1_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM13_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM14_REMAP1)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim14_ch1_pwm_pc9: tim14_ch1_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM14_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -543,7 +543,7 @@
 			};
 
 			tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM15_REMAP0)>;
 			};
 
 			tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
@@ -551,7 +551,7 @@
 			};
 
 			tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
 			tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
@@ -559,7 +559,7 @@
 			};
 
 			tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
 			tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
@@ -567,11 +567,11 @@
 			};
 
 			tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
 			tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
 			tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
@@ -579,11 +579,11 @@
 			};
 
 			tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
 			tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
 			tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
@@ -591,7 +591,7 @@
 			};
 
 			tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM17_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -603,31 +603,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -639,53 +639,53 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -699,31 +699,31 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f101c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(4-6)tx-pinctrl.dtsi
@@ -55,207 +55,207 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -267,7 +267,7 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -279,35 +279,35 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f101c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(8-b)tx-pinctrl.dtsi
@@ -55,12 +55,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -72,12 +72,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -89,12 +89,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -106,11 +106,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -120,11 +120,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -134,11 +134,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -148,11 +148,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -162,11 +162,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -176,12 +176,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -193,11 +193,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -207,115 +207,115 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -327,19 +327,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -351,51 +351,51 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f101c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(8-b)ux-pinctrl.dtsi
@@ -55,12 +55,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -72,12 +72,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -89,12 +89,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -106,11 +106,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -120,11 +120,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -134,11 +134,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -148,11 +148,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -162,11 +162,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -176,12 +176,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -193,11 +193,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -207,115 +207,115 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -327,19 +327,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -351,51 +351,51 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f101r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(4-6)tx-pinctrl.dtsi
@@ -79,223 +79,223 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -307,7 +307,7 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -319,35 +319,35 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f101r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(8-b)tx-pinctrl.dtsi
@@ -79,12 +79,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -96,12 +96,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -113,12 +113,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -130,11 +130,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -144,11 +144,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -158,11 +158,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -172,11 +172,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -186,11 +186,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -200,12 +200,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -217,11 +217,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -231,131 +231,131 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -367,19 +367,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -391,59 +391,59 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f101r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(c-d-e)tx-pinctrl.dtsi
@@ -89,12 +89,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -106,12 +106,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -123,12 +123,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -138,18 +138,18 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -157,17 +157,17 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -175,17 +175,17 @@
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -193,17 +193,17 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -211,17 +211,17 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -229,18 +229,18 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -250,18 +250,18 @@
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -269,137 +269,137 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -427,19 +427,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -451,37 +451,37 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -495,23 +495,23 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f101r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(f-g)tx-pinctrl.dtsi
@@ -89,12 +89,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -106,12 +106,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -123,12 +123,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -138,18 +138,18 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -157,17 +157,17 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -175,17 +175,17 @@
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -193,17 +193,17 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -211,17 +211,17 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -229,18 +229,18 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -250,18 +250,18 @@
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -269,81 +269,81 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM10_REMAP0)>;
 			};
 
 			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM11_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
@@ -355,75 +355,75 @@
 			};
 
 			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM13_REMAP0)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM14_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -443,11 +443,11 @@
 			};
 
 			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM9_REMAP0)>;
 			};
 
 			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM9_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -459,19 +459,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -483,37 +483,37 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -527,23 +527,23 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f101rbhx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101rbhx-pinctrl.dtsi
@@ -75,12 +75,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -92,12 +92,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -109,12 +109,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -126,11 +126,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -140,11 +140,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -154,11 +154,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -168,11 +168,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -182,11 +182,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -196,12 +196,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -213,11 +213,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -227,131 +227,131 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -363,19 +363,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -387,59 +387,59 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f101t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101t(4-6)ux-pinctrl.dtsi
@@ -55,181 +55,181 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -241,7 +241,7 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -253,35 +253,35 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f101t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101t(8-b)ux-pinctrl.dtsi
@@ -55,189 +55,189 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -249,7 +249,7 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -261,35 +261,35 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f101v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(8-b)tx-pinctrl.dtsi
@@ -79,12 +79,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -96,12 +96,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -113,12 +113,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -130,11 +130,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -144,11 +144,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -158,11 +158,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -172,11 +172,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -186,11 +186,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -200,12 +200,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -217,11 +217,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -231,147 +231,147 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -383,31 +383,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -419,83 +419,83 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 		};

--- a/dts/st/f1/stm32f101v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(c-d-e)tx-pinctrl.dtsi
@@ -89,12 +89,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -106,12 +106,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -123,12 +123,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -138,18 +138,18 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -157,17 +157,17 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -175,17 +175,17 @@
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -193,17 +193,17 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -211,17 +211,17 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -229,18 +229,18 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -250,18 +250,18 @@
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -269,153 +269,153 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -443,31 +443,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -479,53 +479,53 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -539,31 +539,31 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f101v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(f-g)tx-pinctrl.dtsi
@@ -89,12 +89,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -106,12 +106,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -123,12 +123,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -138,18 +138,18 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -157,17 +157,17 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -175,17 +175,17 @@
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -193,17 +193,17 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -211,17 +211,17 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -229,18 +229,18 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -250,18 +250,18 @@
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -269,81 +269,81 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM10_REMAP0)>;
 			};
 
 			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM11_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
@@ -355,91 +355,91 @@
 			};
 
 			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM13_REMAP0)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM14_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -459,19 +459,19 @@
 			};
 
 			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM9_REMAP0)>;
 			};
 
 			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM9_REMAP0)>;
 			};
 
 			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
-				pinmux = <STM32F1_PINMUX('E', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('E', 5, ALTERNATE, TIM9_REMAP1)>;
 			};
 
 			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
-				pinmux = <STM32F1_PINMUX('E', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('E', 6, ALTERNATE, TIM9_REMAP1)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -483,31 +483,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -519,53 +519,53 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -579,31 +579,31 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f101z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101z(c-d-e)tx-pinctrl.dtsi
@@ -89,12 +89,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -106,12 +106,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -123,12 +123,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -138,18 +138,18 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -157,17 +157,17 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -175,17 +175,17 @@
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -193,17 +193,17 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -211,17 +211,17 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -229,18 +229,18 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -250,18 +250,18 @@
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -269,153 +269,153 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -443,31 +443,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -479,53 +479,53 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -539,31 +539,31 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f101z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101z(f-g)tx-pinctrl.dtsi
@@ -89,12 +89,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -106,12 +106,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -123,12 +123,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -138,18 +138,18 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -157,17 +157,17 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -175,17 +175,17 @@
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -193,17 +193,17 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -211,17 +211,17 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -229,18 +229,18 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -250,18 +250,18 @@
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -269,89 +269,89 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM10_REMAP0)>;
 			};
 
 			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
-				pinmux = <STM32F1_PINMUX('F', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('F', 6, ALTERNATE, TIM10_REMAP1)>;
 			};
 
 			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM11_REMAP0)>;
 			};
 
 			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
-				pinmux = <STM32F1_PINMUX('F', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('F', 7, ALTERNATE, TIM11_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
@@ -363,99 +363,99 @@
 			};
 
 			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM13_REMAP0)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
-				pinmux = <STM32F1_PINMUX('F', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('F', 8, ALTERNATE, TIM13_REMAP1)>;
 			};
 
 			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM14_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
-				pinmux = <STM32F1_PINMUX('F', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('F', 9, ALTERNATE, TIM14_REMAP1)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -475,19 +475,19 @@
 			};
 
 			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM9_REMAP0)>;
 			};
 
 			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM9_REMAP0)>;
 			};
 
 			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
-				pinmux = <STM32F1_PINMUX('E', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('E', 5, ALTERNATE, TIM9_REMAP1)>;
 			};
 
 			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
-				pinmux = <STM32F1_PINMUX('E', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('E', 6, ALTERNATE, TIM9_REMAP1)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -499,31 +499,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -535,53 +535,53 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -595,31 +595,31 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
@@ -55,207 +55,207 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -267,7 +267,7 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -279,35 +279,35 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* USB */

--- a/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
@@ -55,12 +55,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -72,12 +72,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -89,12 +89,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -106,11 +106,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -120,11 +120,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -134,11 +134,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -148,11 +148,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -162,11 +162,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -176,12 +176,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -193,11 +193,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -207,115 +207,115 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -327,19 +327,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -351,51 +351,51 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			/* USB */

--- a/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
@@ -79,223 +79,223 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -307,7 +307,7 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -319,35 +319,35 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* USB */

--- a/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
@@ -79,12 +79,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -96,12 +96,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -113,12 +113,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -130,11 +130,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -144,11 +144,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -158,11 +158,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -172,11 +172,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -186,11 +186,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -200,12 +200,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -217,11 +217,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -231,131 +231,131 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -367,19 +367,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -391,59 +391,59 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* USB */

--- a/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
@@ -95,283 +95,283 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -383,7 +383,7 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -395,35 +395,35 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* USB */

--- a/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
@@ -95,32 +95,32 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -132,12 +132,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -149,12 +149,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -166,11 +166,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -180,11 +180,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -194,11 +194,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -208,11 +208,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -222,11 +222,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -236,12 +236,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -253,11 +253,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -267,171 +267,171 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -443,19 +443,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -467,51 +467,51 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			/* USB */

--- a/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
@@ -95,283 +95,283 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -383,7 +383,7 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -395,35 +395,35 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* USB */

--- a/dts/st/f1/stm32f103cbux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103cbux-pinctrl.dtsi
@@ -95,32 +95,32 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -132,12 +132,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -149,12 +149,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -166,11 +166,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -180,11 +180,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -194,11 +194,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -208,11 +208,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -222,11 +222,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -236,12 +236,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -253,11 +253,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -267,171 +267,171 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -443,19 +443,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -467,51 +467,51 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			/* USB */

--- a/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
@@ -135,299 +135,299 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -439,7 +439,7 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -451,35 +451,35 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* USB */

--- a/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
@@ -143,299 +143,299 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -447,7 +447,7 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -459,35 +459,35 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* USB */

--- a/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
@@ -135,32 +135,32 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -172,12 +172,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -189,12 +189,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -206,11 +206,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -220,11 +220,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -234,11 +234,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -248,11 +248,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -262,11 +262,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -276,12 +276,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -293,11 +293,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -307,187 +307,187 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -499,19 +499,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -523,59 +523,59 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* USB */

--- a/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
@@ -143,32 +143,32 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -180,12 +180,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -197,12 +197,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -214,11 +214,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -228,11 +228,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -242,11 +242,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -256,11 +256,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -270,11 +270,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -284,12 +284,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -301,11 +301,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -315,187 +315,187 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -507,19 +507,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -531,59 +531,59 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* USB */

--- a/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
@@ -175,21 +175,21 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			/* DAC_OUT */
@@ -205,12 +205,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -222,12 +222,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -243,7 +243,7 @@
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* I2S_SD */
@@ -253,7 +253,7 @@
 			};
 
 			i2s3_sd_pb5: i2s3_sd_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* I2S_WS */
@@ -263,18 +263,18 @@
 			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -284,18 +284,18 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -303,17 +303,17 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -321,17 +321,17 @@
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -339,17 +339,17 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -357,17 +357,17 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -375,18 +375,18 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -396,18 +396,18 @@
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -415,193 +415,193 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -657,19 +657,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -681,37 +681,37 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -725,23 +725,23 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
@@ -163,21 +163,21 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			/* DAC_OUT */
@@ -193,12 +193,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -210,12 +210,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -231,7 +231,7 @@
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* I2S_SD */
@@ -241,7 +241,7 @@
 			};
 
 			i2s3_sd_pb5: i2s3_sd_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* I2S_WS */
@@ -251,18 +251,18 @@
 			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -272,18 +272,18 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -291,17 +291,17 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -309,17 +309,17 @@
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -327,17 +327,17 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -345,17 +345,17 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -363,18 +363,18 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -384,18 +384,18 @@
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -403,193 +403,193 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -645,19 +645,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -669,37 +669,37 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -713,23 +713,23 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
@@ -175,21 +175,21 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			/* DAC_OUT */
@@ -205,12 +205,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -222,12 +222,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -243,7 +243,7 @@
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* I2S_SD */
@@ -253,7 +253,7 @@
 			};
 
 			i2s3_sd_pb5: i2s3_sd_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* I2S_WS */
@@ -263,18 +263,18 @@
 			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -284,18 +284,18 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -303,17 +303,17 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -321,17 +321,17 @@
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -339,17 +339,17 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -357,17 +357,17 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -375,18 +375,18 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -396,18 +396,18 @@
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -415,137 +415,137 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM10_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM11_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
@@ -557,75 +557,75 @@
 			};
 
 			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM13_REMAP0)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM14_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -673,11 +673,11 @@
 			};
 
 			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM9_REMAP0)>;
 			};
 
 			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM9_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -689,19 +689,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -713,37 +713,37 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -757,23 +757,23 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
@@ -95,237 +95,237 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -337,7 +337,7 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -349,35 +349,35 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* USB */

--- a/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
@@ -95,245 +95,245 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -345,7 +345,7 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -357,35 +357,35 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			/* USB */

--- a/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
@@ -143,40 +143,40 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			can_rx_pd0: can_rx_pd0 {
-				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN_REMAP2)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			can_tx_pd1: can_tx_pd1 {
-				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN_REMAP2)>;
 			};
 
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -188,12 +188,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -205,12 +205,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -222,11 +222,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -236,11 +236,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -250,11 +250,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -264,11 +264,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -278,11 +278,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -292,12 +292,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -309,11 +309,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -323,231 +323,231 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
-				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
-				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
-				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
-				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
-				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
-				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
-				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -559,31 +559,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -595,83 +595,83 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* USB */

--- a/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
@@ -143,40 +143,40 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			can_rx_pd0: can_rx_pd0 {
-				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN_REMAP2)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			can_tx_pd1: can_tx_pd1 {
-				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN_REMAP2)>;
 			};
 
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -188,12 +188,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -205,12 +205,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -222,11 +222,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -236,11 +236,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -250,11 +250,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -264,11 +264,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -278,11 +278,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -292,12 +292,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -309,11 +309,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -323,231 +323,231 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
-				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
-				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
-				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
-				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
-				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
-				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
-				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -559,31 +559,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -595,83 +595,83 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* USB */

--- a/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
@@ -175,29 +175,29 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			can_rx_pd0: can_rx_pd0 {
-				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN_REMAP2)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			can_tx_pd1: can_tx_pd1 {
-				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN_REMAP2)>;
 			};
 
 			/* DAC_OUT */
@@ -213,12 +213,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -230,12 +230,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -251,7 +251,7 @@
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* I2S_SD */
@@ -261,7 +261,7 @@
 			};
 
 			i2s3_sd_pb5: i2s3_sd_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* I2S_WS */
@@ -271,18 +271,18 @@
 			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -292,18 +292,18 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -311,17 +311,17 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -329,17 +329,17 @@
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -347,17 +347,17 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -365,17 +365,17 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -383,18 +383,18 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -404,18 +404,18 @@
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -423,237 +423,237 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
-				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
-				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
-				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
-				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
-				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
-				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
-				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -709,31 +709,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -745,53 +745,53 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -805,31 +805,31 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
@@ -175,29 +175,29 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			can_rx_pd0: can_rx_pd0 {
-				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN_REMAP2)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			can_tx_pd1: can_tx_pd1 {
-				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN_REMAP2)>;
 			};
 
 			/* DAC_OUT */
@@ -213,12 +213,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -230,12 +230,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -251,7 +251,7 @@
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* I2S_SD */
@@ -261,7 +261,7 @@
 			};
 
 			i2s3_sd_pb5: i2s3_sd_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* I2S_WS */
@@ -271,18 +271,18 @@
 			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -292,18 +292,18 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -311,17 +311,17 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -329,17 +329,17 @@
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -347,17 +347,17 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -365,17 +365,17 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -383,18 +383,18 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -404,18 +404,18 @@
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -423,237 +423,237 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
-				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
-				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
-				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
-				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
-				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
-				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
-				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -709,31 +709,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -745,53 +745,53 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -805,31 +805,31 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
@@ -175,29 +175,29 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			can_rx_pd0: can_rx_pd0 {
-				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN_REMAP2)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			can_tx_pd1: can_tx_pd1 {
-				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN_REMAP2)>;
 			};
 
 			/* DAC_OUT */
@@ -213,12 +213,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -230,12 +230,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -251,7 +251,7 @@
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* I2S_SD */
@@ -261,7 +261,7 @@
 			};
 
 			i2s3_sd_pb5: i2s3_sd_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* I2S_WS */
@@ -271,18 +271,18 @@
 			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -292,18 +292,18 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -311,17 +311,17 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -329,17 +329,17 @@
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -347,17 +347,17 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -365,17 +365,17 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -383,18 +383,18 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -404,18 +404,18 @@
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -423,165 +423,165 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM10_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM11_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
-				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
-				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
-				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
-				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
-				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
-				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
-				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
@@ -593,91 +593,91 @@
 			};
 
 			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM13_REMAP0)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM14_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -725,19 +725,19 @@
 			};
 
 			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM9_REMAP0)>;
 			};
 
 			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM9_REMAP0)>;
 			};
 
 			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
-				pinmux = <STM32F1_PINMUX('E', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('E', 5, ALTERNATE, TIM9_REMAP1)>;
 			};
 
 			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
-				pinmux = <STM32F1_PINMUX('E', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('E', 6, ALTERNATE, TIM9_REMAP1)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -749,31 +749,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -785,53 +785,53 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -845,31 +845,31 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f103vbix-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103vbix-pinctrl.dtsi
@@ -143,40 +143,40 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			can_rx_pd0: can_rx_pd0 {
-				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN_REMAP2)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			can_tx_pd1: can_tx_pd1 {
-				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN_REMAP2)>;
 			};
 
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -188,12 +188,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -205,12 +205,12 @@
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -222,11 +222,11 @@
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -236,11 +236,11 @@
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -250,11 +250,11 @@
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -264,11 +264,11 @@
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -278,11 +278,11 @@
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -292,12 +292,12 @@
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -309,11 +309,11 @@
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -323,231 +323,231 @@
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
-				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
-				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
-				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
-				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
-				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
-				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
-				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -559,31 +559,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -595,83 +595,83 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* USB */

--- a/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
@@ -195,29 +195,29 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			can_rx_pd0: can_rx_pd0 {
-				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN_REMAP2)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			can_tx_pd1: can_tx_pd1 {
-				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN_REMAP2)>;
 			};
 
 			/* DAC_OUT */
@@ -233,12 +233,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -250,12 +250,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -271,7 +271,7 @@
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* I2S_SD */
@@ -281,7 +281,7 @@
 			};
 
 			i2s3_sd_pb5: i2s3_sd_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* I2S_WS */
@@ -291,18 +291,18 @@
 			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -312,18 +312,18 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -331,17 +331,17 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -349,17 +349,17 @@
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -367,17 +367,17 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -385,17 +385,17 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -403,18 +403,18 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -424,18 +424,18 @@
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -443,237 +443,237 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
-				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
-				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
-				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
-				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
-				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
-				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
-				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -729,31 +729,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -765,53 +765,53 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -825,31 +825,31 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
@@ -195,29 +195,29 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			can_rx_pd0: can_rx_pd0 {
-				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN_REMAP2)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			can_tx_pd1: can_tx_pd1 {
-				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN_REMAP2)>;
 			};
 
 			/* DAC_OUT */
@@ -233,12 +233,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -250,12 +250,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -271,7 +271,7 @@
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* I2S_SD */
@@ -281,7 +281,7 @@
 			};
 
 			i2s3_sd_pb5: i2s3_sd_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* I2S_WS */
@@ -291,18 +291,18 @@
 			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -312,18 +312,18 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -331,17 +331,17 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -349,17 +349,17 @@
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -367,17 +367,17 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -385,17 +385,17 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -403,18 +403,18 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -424,18 +424,18 @@
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -443,237 +443,237 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
-				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
-				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
-				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
-				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
-				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
-				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
-				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -729,31 +729,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -765,53 +765,53 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -825,31 +825,31 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
@@ -195,29 +195,29 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			can_rx_pd0: can_rx_pd0 {
-				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN_REMAP2)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			can_tx_pd1: can_tx_pd1 {
-				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN_REMAP2)>;
 			};
 
 			/* DAC_OUT */
@@ -233,12 +233,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -250,12 +250,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -271,7 +271,7 @@
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* I2S_SD */
@@ -281,7 +281,7 @@
 			};
 
 			i2s3_sd_pb5: i2s3_sd_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* I2S_WS */
@@ -291,18 +291,18 @@
 			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -312,18 +312,18 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -331,17 +331,17 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -349,17 +349,17 @@
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -367,17 +367,17 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -385,17 +385,17 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -403,18 +403,18 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -424,18 +424,18 @@
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -443,173 +443,173 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM10_REMAP0)>;
 			};
 
 			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
-				pinmux = <STM32F1_PINMUX('F', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('F', 6, ALTERNATE, TIM10_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM11_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
-				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
-				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
-				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
-				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
-				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
-				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
-				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
-				pinmux = <STM32F1_PINMUX('F', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('F', 7, ALTERNATE, TIM11_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
@@ -621,99 +621,99 @@
 			};
 
 			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM13_REMAP0)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
-				pinmux = <STM32F1_PINMUX('F', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('F', 8, ALTERNATE, TIM13_REMAP1)>;
 			};
 
 			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM14_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
-				pinmux = <STM32F1_PINMUX('F', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('F', 9, ALTERNATE, TIM14_REMAP1)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -761,19 +761,19 @@
 			};
 
 			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM9_REMAP0)>;
 			};
 
 			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM9_REMAP0)>;
 			};
 
 			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
-				pinmux = <STM32F1_PINMUX('E', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('E', 5, ALTERNATE, TIM9_REMAP1)>;
 			};
 
 			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
-				pinmux = <STM32F1_PINMUX('E', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('E', 6, ALTERNATE, TIM9_REMAP1)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -785,31 +785,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -821,53 +821,53 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -881,31 +881,31 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
@@ -195,29 +195,29 @@
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
 			can_rx_pb8: can_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
 			can_rx_pd0: can_rx_pd0 {
-				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN_REMAP2)>;
 			};
 
 			/* CAN_TX */
 
 			can_tx_pa12: can_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
 			can_tx_pb9: can_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
 			can_tx_pd1: can_tx_pd1 {
-				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN_REMAP2)>;
 			};
 
 			/* DAC_OUT */
@@ -233,12 +233,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -250,12 +250,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -271,7 +271,7 @@
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* I2S_SD */
@@ -281,7 +281,7 @@
 			};
 
 			i2s3_sd_pb5: i2s3_sd_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* I2S_WS */
@@ -291,18 +291,18 @@
 			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -312,18 +312,18 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -331,17 +331,17 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -349,17 +349,17 @@
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -367,17 +367,17 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -385,17 +385,17 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -403,18 +403,18 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -424,18 +424,18 @@
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -443,173 +443,173 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM10_REMAP0)>;
 			};
 
 			tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
-				pinmux = <STM32F1_PINMUX('F', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('F', 6, ALTERNATE, TIM10_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM11_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
-				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
-				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
-				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
-				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
-				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
-				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
-				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
-				pinmux = <STM32F1_PINMUX('F', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('F', 7, ALTERNATE, TIM11_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
@@ -621,99 +621,99 @@
 			};
 
 			tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM13_REMAP0)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
-				pinmux = <STM32F1_PINMUX('F', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('F', 8, ALTERNATE, TIM13_REMAP1)>;
 			};
 
 			tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM14_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
-				pinmux = <STM32F1_PINMUX('F', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('F', 9, ALTERNATE, TIM14_REMAP1)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -761,19 +761,19 @@
 			};
 
 			tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM9_REMAP0)>;
 			};
 
 			tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM9_REMAP0)>;
 			};
 
 			tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
-				pinmux = <STM32F1_PINMUX('E', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('E', 5, ALTERNATE, TIM9_REMAP1)>;
 			};
 
 			tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
-				pinmux = <STM32F1_PINMUX('E', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('E', 6, ALTERNATE, TIM9_REMAP1)>;
 			};
 
 			/* UART_CTS / USART_CTS */
@@ -785,31 +785,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -821,53 +821,53 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -881,31 +881,31 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
@@ -143,37 +143,37 @@
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN1_REMAP0)>;
 			};
 
 			can1_rx_pb8: can1_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN1_REMAP1)>;
 			};
 
 			can2_rx_pb5: can2_rx_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, CAN2_REMAP1)>;
 			};
 
 			can2_rx_pb12: can2_rx_pb12 {
-				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, CAN2_REMAP0)>;
 			};
 
 			/* CAN_TX */
 
 			can1_tx_pa12: can1_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN1_REMAP0)>;
 			};
 
 			can1_tx_pb9: can1_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN1_REMAP1)>;
 			};
 
 			can2_tx_pb6: can2_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, CAN2_REMAP1)>;
 			};
 
 			can2_tx_pb13: can2_tx_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, CAN2_REMAP0)>;
 			};
 
 			/* DAC_OUT */
@@ -189,12 +189,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -206,12 +206,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -227,11 +227,11 @@
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			i2s3_ck_pc10: i2s3_ck_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, I2S3_REMAP1)>;
 			};
 
 			/* I2S_SD */
@@ -241,11 +241,11 @@
 			};
 
 			i2s3_sd_pb5: i2s3_sd_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			i2s3_sd_pc12: i2s3_sd_pc12 {
-				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, I2S3_REMAP1)>;
 			};
 
 			/* I2S_WS */
@@ -255,22 +255,22 @@
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, I2S3_REMAP1)>;
 			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -280,23 +280,23 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi3_miso_master_pc11: spi3_miso_master_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -304,21 +304,21 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			spi3_mosi_master_pc12: spi3_mosi_master_pc12 {
-				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -326,21 +326,21 @@
 			};
 
 			spi3_nss_master_pa4: spi3_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -348,21 +348,21 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			spi3_sck_master_pc10: spi3_sck_master_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -370,21 +370,21 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			spi3_miso_slave_pc11: spi3_miso_slave_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -392,22 +392,22 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			spi3_mosi_slave_pc12: spi3_mosi_slave_pc12 {
-				pinmux = <STM32F1_PINMUX('C', 12, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 12, GPIO_IN, SPI3_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -417,23 +417,23 @@
 			};
 
 			spi3_nss_slave_pa4: spi3_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-up;
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -441,197 +441,197 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			spi3_sck_slave_pc10: spi3_sck_slave_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, SPI3_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -659,19 +659,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -683,37 +683,37 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -727,23 +727,23 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
@@ -143,45 +143,45 @@
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN1_REMAP0)>;
 			};
 
 			can1_rx_pb8: can1_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN1_REMAP1)>;
 			};
 
 			can1_rx_pd0: can1_rx_pd0 {
-				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN1_REMAP2)>;
 			};
 
 			can2_rx_pb5: can2_rx_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, CAN2_REMAP1)>;
 			};
 
 			can2_rx_pb12: can2_rx_pb12 {
-				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, CAN2_REMAP0)>;
 			};
 
 			/* CAN_TX */
 
 			can1_tx_pa12: can1_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN1_REMAP0)>;
 			};
 
 			can1_tx_pb9: can1_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN1_REMAP1)>;
 			};
 
 			can1_tx_pd1: can1_tx_pd1 {
-				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN1_REMAP2)>;
 			};
 
 			can2_tx_pb6: can2_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, CAN2_REMAP1)>;
 			};
 
 			can2_tx_pb13: can2_tx_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, CAN2_REMAP0)>;
 			};
 
 			/* DAC_OUT */
@@ -197,12 +197,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -214,12 +214,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -235,11 +235,11 @@
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			i2s3_ck_pc10: i2s3_ck_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, I2S3_REMAP1)>;
 			};
 
 			/* I2S_SD */
@@ -249,11 +249,11 @@
 			};
 
 			i2s3_sd_pb5: i2s3_sd_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			i2s3_sd_pc12: i2s3_sd_pc12 {
-				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, I2S3_REMAP1)>;
 			};
 
 			/* I2S_WS */
@@ -263,22 +263,22 @@
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, I2S3_REMAP1)>;
 			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -288,23 +288,23 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi3_miso_master_pc11: spi3_miso_master_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -312,21 +312,21 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			spi3_mosi_master_pc12: spi3_mosi_master_pc12 {
-				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -334,21 +334,21 @@
 			};
 
 			spi3_nss_master_pa4: spi3_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -356,21 +356,21 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			spi3_sck_master_pc10: spi3_sck_master_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -378,21 +378,21 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			spi3_miso_slave_pc11: spi3_miso_slave_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -400,22 +400,22 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			spi3_mosi_slave_pc12: spi3_mosi_slave_pc12 {
-				pinmux = <STM32F1_PINMUX('C', 12, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 12, GPIO_IN, SPI3_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -425,23 +425,23 @@
 			};
 
 			spi3_nss_slave_pa4: spi3_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-up;
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -449,241 +449,241 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			spi3_sck_slave_pc10: spi3_sck_slave_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, SPI3_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
-				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
-				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
-				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
-				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
-				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
-				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
-				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -711,31 +711,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -747,53 +747,53 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -807,31 +807,31 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
@@ -143,45 +143,45 @@
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN1_REMAP0)>;
 			};
 
 			can1_rx_pb8: can1_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN1_REMAP1)>;
 			};
 
 			can1_rx_pd0: can1_rx_pd0 {
-				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN1_REMAP2)>;
 			};
 
 			can2_rx_pb5: can2_rx_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, CAN2_REMAP1)>;
 			};
 
 			can2_rx_pb12: can2_rx_pb12 {
-				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, CAN2_REMAP0)>;
 			};
 
 			/* CAN_TX */
 
 			can1_tx_pa12: can1_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN1_REMAP0)>;
 			};
 
 			can1_tx_pb9: can1_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN1_REMAP1)>;
 			};
 
 			can1_tx_pd1: can1_tx_pd1 {
-				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN1_REMAP2)>;
 			};
 
 			can2_tx_pb6: can2_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, CAN2_REMAP1)>;
 			};
 
 			can2_tx_pb13: can2_tx_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, CAN2_REMAP0)>;
 			};
 
 			/* DAC_OUT */
@@ -197,12 +197,12 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -214,12 +214,12 @@
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -235,11 +235,11 @@
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			i2s3_ck_pc10: i2s3_ck_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, I2S3_REMAP1)>;
 			};
 
 			/* I2S_SD */
@@ -249,11 +249,11 @@
 			};
 
 			i2s3_sd_pb5: i2s3_sd_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			i2s3_sd_pc12: i2s3_sd_pc12 {
-				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, I2S3_REMAP1)>;
 			};
 
 			/* I2S_WS */
@@ -263,22 +263,22 @@
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, I2S3_REMAP1)>;
 			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -288,23 +288,23 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi3_miso_master_pc11: spi3_miso_master_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -312,21 +312,21 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			spi3_mosi_master_pc12: spi3_mosi_master_pc12 {
-				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -334,21 +334,21 @@
 			};
 
 			spi3_nss_master_pa4: spi3_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -356,21 +356,21 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			spi3_sck_master_pc10: spi3_sck_master_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -378,21 +378,21 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			spi3_miso_slave_pc11: spi3_miso_slave_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -400,22 +400,22 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			spi3_mosi_slave_pc12: spi3_mosi_slave_pc12 {
-				pinmux = <STM32F1_PINMUX('C', 12, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 12, GPIO_IN, SPI3_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -425,23 +425,23 @@
 			};
 
 			spi3_nss_slave_pa4: spi3_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-up;
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -449,241 +449,241 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			spi3_sck_slave_pc10: spi3_sck_slave_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, SPI3_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
-				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
-				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
-				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
-				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
-				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
-				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
-				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -711,31 +711,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -747,53 +747,53 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -807,31 +807,31 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
@@ -143,37 +143,37 @@
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN1_REMAP0)>;
 			};
 
 			can1_rx_pb8: can1_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN1_REMAP1)>;
 			};
 
 			can2_rx_pb5: can2_rx_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, CAN2_REMAP1)>;
 			};
 
 			can2_rx_pb12: can2_rx_pb12 {
-				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, CAN2_REMAP0)>;
 			};
 
 			/* CAN_TX */
 
 			can1_tx_pa12: can1_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN1_REMAP0)>;
 			};
 
 			can1_tx_pb9: can1_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN1_REMAP1)>;
 			};
 
 			can2_tx_pb6: can2_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, CAN2_REMAP1)>;
 			};
 
 			can2_tx_pb13: can2_tx_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, CAN2_REMAP0)>;
 			};
 
 			/* DAC_OUT */
@@ -201,7 +201,7 @@
 			/* ETH_CRS_DV */
 
 			eth_crs_dv_pa7: eth_crs_dv_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, ETH_REMAP0)>;
 			};
 
 			/* ETH_MDC */
@@ -234,25 +234,25 @@
 			/* ETH_RXD0 */
 
 			eth_rxd0_pc4: eth_rxd0_pc4 {
-				pinmux = <STM32F1_PINMUX('C', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('C', 4, GPIO_IN, ETH_REMAP0)>;
 			};
 
 			/* ETH_RXD1 */
 
 			eth_rxd1_pc5: eth_rxd1_pc5 {
-				pinmux = <STM32F1_PINMUX('C', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('C', 5, GPIO_IN, ETH_REMAP0)>;
 			};
 
 			/* ETH_RXD2 */
 
 			eth_rxd2_pb0: eth_rxd2_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, ETH_REMAP0)>;
 			};
 
 			/* ETH_RXD3 */
 
 			eth_rxd3_pb1: eth_rxd3_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, ETH_REMAP0)>;
 			};
 
 			/* ETH_RX_CLK */
@@ -264,7 +264,7 @@
 			/* ETH_RX_DV */
 
 			eth_rx_dv_pa7: eth_rx_dv_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, ETH_REMAP0)>;
 			};
 
 			/* ETH_RX_ER */
@@ -317,24 +317,24 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -345,11 +345,11 @@
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			i2s3_ck_pc10: i2s3_ck_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, I2S3_REMAP1)>;
 			};
 
 			/* I2S_SD */
@@ -359,11 +359,11 @@
 			};
 
 			i2s3_sd_pb5: i2s3_sd_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			i2s3_sd_pc12: i2s3_sd_pc12 {
-				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, I2S3_REMAP1)>;
 			};
 
 			/* I2S_WS */
@@ -373,22 +373,22 @@
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, I2S3_REMAP1)>;
 			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -398,23 +398,23 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi3_miso_master_pc11: spi3_miso_master_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -422,21 +422,21 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			spi3_mosi_master_pc12: spi3_mosi_master_pc12 {
-				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -444,21 +444,21 @@
 			};
 
 			spi3_nss_master_pa4: spi3_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -466,21 +466,21 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			spi3_sck_master_pc10: spi3_sck_master_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -488,21 +488,21 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			spi3_miso_slave_pc11: spi3_miso_slave_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -510,22 +510,22 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			spi3_mosi_slave_pc12: spi3_mosi_slave_pc12 {
-				pinmux = <STM32F1_PINMUX('C', 12, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 12, GPIO_IN, SPI3_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -535,23 +535,23 @@
 			};
 
 			spi3_nss_slave_pa4: spi3_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-up;
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -559,197 +559,197 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			spi3_sck_slave_pc10: spi3_sck_slave_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, SPI3_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -777,19 +777,19 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -801,37 +801,37 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -845,23 +845,23 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
@@ -143,45 +143,45 @@
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN1_REMAP0)>;
 			};
 
 			can1_rx_pb8: can1_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN1_REMAP1)>;
 			};
 
 			can1_rx_pd0: can1_rx_pd0 {
-				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN1_REMAP2)>;
 			};
 
 			can2_rx_pb5: can2_rx_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, CAN2_REMAP1)>;
 			};
 
 			can2_rx_pb12: can2_rx_pb12 {
-				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, CAN2_REMAP0)>;
 			};
 
 			/* CAN_TX */
 
 			can1_tx_pa12: can1_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN1_REMAP0)>;
 			};
 
 			can1_tx_pb9: can1_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN1_REMAP1)>;
 			};
 
 			can1_tx_pd1: can1_tx_pd1 {
-				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN1_REMAP2)>;
 			};
 
 			can2_tx_pb6: can2_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, CAN2_REMAP1)>;
 			};
 
 			can2_tx_pb13: can2_tx_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, CAN2_REMAP0)>;
 			};
 
 			/* DAC_OUT */
@@ -209,11 +209,11 @@
 			/* ETH_CRS_DV */
 
 			eth_crs_dv_pa7: eth_crs_dv_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, ETH_REMAP0)>;
 			};
 
 			eth_crs_dv_pd8: eth_crs_dv_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 8, GPIO_IN, ETH_REMAP1)>;
 			};
 
 			/* ETH_MDC */
@@ -246,41 +246,41 @@
 			/* ETH_RXD0 */
 
 			eth_rxd0_pc4: eth_rxd0_pc4 {
-				pinmux = <STM32F1_PINMUX('C', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('C', 4, GPIO_IN, ETH_REMAP0)>;
 			};
 
 			eth_rxd0_pd9: eth_rxd0_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, ETH_REMAP1)>;
 			};
 
 			/* ETH_RXD1 */
 
 			eth_rxd1_pc5: eth_rxd1_pc5 {
-				pinmux = <STM32F1_PINMUX('C', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('C', 5, GPIO_IN, ETH_REMAP0)>;
 			};
 
 			eth_rxd1_pd10: eth_rxd1_pd10 {
-				pinmux = <STM32F1_PINMUX('D', 10, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 10, GPIO_IN, ETH_REMAP1)>;
 			};
 
 			/* ETH_RXD2 */
 
 			eth_rxd2_pb0: eth_rxd2_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, ETH_REMAP0)>;
 			};
 
 			eth_rxd2_pd11: eth_rxd2_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, ETH_REMAP1)>;
 			};
 
 			/* ETH_RXD3 */
 
 			eth_rxd3_pb1: eth_rxd3_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, ETH_REMAP0)>;
 			};
 
 			eth_rxd3_pd12: eth_rxd3_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, ETH_REMAP1)>;
 			};
 
 			/* ETH_RX_CLK */
@@ -292,11 +292,11 @@
 			/* ETH_RX_DV */
 
 			eth_rx_dv_pa7: eth_rx_dv_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, ETH_REMAP0)>;
 			};
 
 			eth_rx_dv_pd8: eth_rx_dv_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 8, GPIO_IN, ETH_REMAP1)>;
 			};
 
 			/* ETH_RX_ER */
@@ -349,24 +349,24 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -377,11 +377,11 @@
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			i2s3_ck_pc10: i2s3_ck_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, I2S3_REMAP1)>;
 			};
 
 			/* I2S_SD */
@@ -391,11 +391,11 @@
 			};
 
 			i2s3_sd_pb5: i2s3_sd_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			i2s3_sd_pc12: i2s3_sd_pc12 {
-				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, I2S3_REMAP1)>;
 			};
 
 			/* I2S_WS */
@@ -405,22 +405,22 @@
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, I2S3_REMAP1)>;
 			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -430,23 +430,23 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi3_miso_master_pc11: spi3_miso_master_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -454,21 +454,21 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			spi3_mosi_master_pc12: spi3_mosi_master_pc12 {
-				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -476,21 +476,21 @@
 			};
 
 			spi3_nss_master_pa4: spi3_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -498,21 +498,21 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			spi3_sck_master_pc10: spi3_sck_master_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -520,21 +520,21 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			spi3_miso_slave_pc11: spi3_miso_slave_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -542,22 +542,22 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			spi3_mosi_slave_pc12: spi3_mosi_slave_pc12 {
-				pinmux = <STM32F1_PINMUX('C', 12, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 12, GPIO_IN, SPI3_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -567,23 +567,23 @@
 			};
 
 			spi3_nss_slave_pa4: spi3_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-up;
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -591,241 +591,241 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			spi3_sck_slave_pc10: spi3_sck_slave_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, SPI3_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
-				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
-				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
-				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
-				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
-				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
-				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
-				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -853,31 +853,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -889,53 +889,53 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -949,31 +949,31 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/dts/st/f1/stm32f107vchx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107vchx-pinctrl.dtsi
@@ -143,45 +143,45 @@
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN1_REMAP0)>;
 			};
 
 			can1_rx_pb8: can1_rx_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN1_REMAP1)>;
 			};
 
 			can1_rx_pd0: can1_rx_pd0 {
-				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN1_REMAP2)>;
 			};
 
 			can2_rx_pb5: can2_rx_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, CAN2_REMAP1)>;
 			};
 
 			can2_rx_pb12: can2_rx_pb12 {
-				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, CAN2_REMAP0)>;
 			};
 
 			/* CAN_TX */
 
 			can1_tx_pa12: can1_tx_pa12 {
-				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN1_REMAP0)>;
 			};
 
 			can1_tx_pb9: can1_tx_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN1_REMAP1)>;
 			};
 
 			can1_tx_pd1: can1_tx_pd1 {
-				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN1_REMAP2)>;
 			};
 
 			can2_tx_pb6: can2_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, CAN2_REMAP1)>;
 			};
 
 			can2_tx_pb13: can2_tx_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, CAN2_REMAP0)>;
 			};
 
 			/* DAC_OUT */
@@ -209,11 +209,11 @@
 			/* ETH_CRS_DV */
 
 			eth_crs_dv_pa7: eth_crs_dv_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, ETH_REMAP0)>;
 			};
 
 			eth_crs_dv_pd8: eth_crs_dv_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 8, GPIO_IN, ETH_REMAP1)>;
 			};
 
 			/* ETH_MDC */
@@ -246,41 +246,41 @@
 			/* ETH_RXD0 */
 
 			eth_rxd0_pc4: eth_rxd0_pc4 {
-				pinmux = <STM32F1_PINMUX('C', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('C', 4, GPIO_IN, ETH_REMAP0)>;
 			};
 
 			eth_rxd0_pd9: eth_rxd0_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, ETH_REMAP1)>;
 			};
 
 			/* ETH_RXD1 */
 
 			eth_rxd1_pc5: eth_rxd1_pc5 {
-				pinmux = <STM32F1_PINMUX('C', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('C', 5, GPIO_IN, ETH_REMAP0)>;
 			};
 
 			eth_rxd1_pd10: eth_rxd1_pd10 {
-				pinmux = <STM32F1_PINMUX('D', 10, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 10, GPIO_IN, ETH_REMAP1)>;
 			};
 
 			/* ETH_RXD2 */
 
 			eth_rxd2_pb0: eth_rxd2_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, ETH_REMAP0)>;
 			};
 
 			eth_rxd2_pd11: eth_rxd2_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, ETH_REMAP1)>;
 			};
 
 			/* ETH_RXD3 */
 
 			eth_rxd3_pb1: eth_rxd3_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, ETH_REMAP0)>;
 			};
 
 			eth_rxd3_pd12: eth_rxd3_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, ETH_REMAP1)>;
 			};
 
 			/* ETH_RX_CLK */
@@ -292,11 +292,11 @@
 			/* ETH_RX_DV */
 
 			eth_rx_dv_pa7: eth_rx_dv_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, ETH_REMAP0)>;
 			};
 
 			eth_rx_dv_pd8: eth_rx_dv_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 8, GPIO_IN, ETH_REMAP1)>;
 			};
 
 			/* ETH_RX_ER */
@@ -349,24 +349,24 @@
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_scl_pb8: i2c1_scl_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
 			/* I2C_SDA */
 
 			i2c1_sda_pb7: i2c1_sda_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, I2C1_REMAP0)>;
 				drive-open-drain;
 			};
 
 			i2c1_sda_pb9: i2c1_sda_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
 
@@ -377,11 +377,11 @@
 			};
 
 			i2s3_ck_pb3: i2s3_ck_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			i2s3_ck_pc10: i2s3_ck_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, I2S3_REMAP1)>;
 			};
 
 			/* I2S_SD */
@@ -391,11 +391,11 @@
 			};
 
 			i2s3_sd_pb5: i2s3_sd_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			i2s3_sd_pc12: i2s3_sd_pc12 {
-				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, I2S3_REMAP1)>;
 			};
 
 			/* I2S_WS */
@@ -405,22 +405,22 @@
 			};
 
 			i2s3_ws_pa4: i2s3_ws_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, I2S3_REMAP1)>;
 			};
 
 			i2s3_ws_pa15: i2s3_ws_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, I2S3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_MISO */
 
 			spi1_miso_master_pa6: spi1_miso_master_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi1_miso_master_pb4: spi1_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
 
@@ -430,23 +430,23 @@
 			};
 
 			spi3_miso_master_pb4: spi3_miso_master_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-down;
 			};
 
 			spi3_miso_master_pc11: spi3_miso_master_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-down;
 			};
 
 			/* SPI_MASTER_MOSI */
 
 			spi1_mosi_master_pa7: spi1_mosi_master_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_master_pb15: spi2_mosi_master_pb15 {
@@ -454,21 +454,21 @@
 			};
 
 			spi3_mosi_master_pb5: spi3_mosi_master_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			spi3_mosi_master_pc12: spi3_mosi_master_pc12 {
-				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			/* SPI_MASTER_NSS */
 
 			spi1_nss_master_pa4: spi1_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_nss_master_pa15: spi1_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_nss_master_pb12: spi2_nss_master_pb12 {
@@ -476,21 +476,21 @@
 			};
 
 			spi3_nss_master_pa4: spi3_nss_master_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			spi3_nss_master_pa15: spi3_nss_master_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			/* SPI_MASTER_SCK */
 
 			spi1_sck_master_pa5: spi1_sck_master_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_master_pb3: spi1_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_master_pb13: spi2_sck_master_pb13 {
@@ -498,21 +498,21 @@
 			};
 
 			spi3_sck_master_pb3: spi3_sck_master_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			spi3_sck_master_pc10: spi3_sck_master_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MISO */
 
 			spi1_miso_slave_pa6: spi1_miso_slave_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
 			spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
 			spi2_miso_slave_pb14: spi2_miso_slave_pb14 {
@@ -520,21 +520,21 @@
 			};
 
 			spi3_miso_slave_pb4: spi3_miso_slave_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
 			spi3_miso_slave_pc11: spi3_miso_slave_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, SPI3_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_MOSI */
 
 			spi1_mosi_slave_pa7: spi1_mosi_slave_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_mosi_slave_pb15: spi2_mosi_slave_pb15 {
@@ -542,22 +542,22 @@
 			};
 
 			spi3_mosi_slave_pb5: spi3_mosi_slave_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			spi3_mosi_slave_pc12: spi3_mosi_slave_pc12 {
-				pinmux = <STM32F1_PINMUX('C', 12, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 12, GPIO_IN, SPI3_REMAP1)>;
 			};
 
 			/* SPI_SLAVE_NSS */
 
 			spi1_nss_slave_pa4: spi1_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI1_REMAP0)>;
 				bias-pull-up;
 			};
 
 			spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
 
@@ -567,23 +567,23 @@
 			};
 
 			spi3_nss_slave_pa4: spi3_nss_slave_pa4 {
-				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-up;
 			};
 
 			spi3_nss_slave_pa15: spi3_nss_slave_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI3_REMAP0)>;
 				bias-pull-up;
 			};
 
 			/* SPI_SLAVE_SCK */
 
 			spi1_sck_slave_pa5: spi1_sck_slave_pa5 {
-				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
 			spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			spi2_sck_slave_pb13: spi2_sck_slave_pb13 {
@@ -591,241 +591,241 @@
 			};
 
 			spi3_sck_slave_pb3: spi3_sck_slave_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
 			spi3_sck_slave_pc10: spi3_sck_slave_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, SPI3_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
 			tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
-				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
-				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
 			tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
-				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
 			tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
-				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
-				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
-				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
-				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
-				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
-				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
-				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
 			tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
-				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
 			tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
-				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
 			tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
 			tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
-				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
-				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
-				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
 			tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
-				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
-				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
 			tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
-				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
-				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
-				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
-				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
-				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
-				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
 			tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
-				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
-				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
-				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
 			tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
@@ -853,31 +853,31 @@
 			};
 
 			usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, USART2_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart2_cts_pd3: usart2_cts_pd3 {
-				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP0)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pb13: usart3_cts_pb13 {
-				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
 			usart3_cts_pd11: usart3_cts_pd11 {
-				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -889,53 +889,53 @@
 			};
 
 			usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_rts_pd4: usart2_rts_pd4 {
-				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_rts_pb14: usart3_rts_pb14 {
-				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_rts_pd12: usart3_rts_pd12 {
-				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			/* UART_RX / USART_RX */
 
 			usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
 			usart1_rx_pb7: usart1_rx_pb7 {
-				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
 			usart2_rx_pa3: usart2_rx_pa3 {
-				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
 			usart2_rx_pd6: usart2_rx_pd6 {
-				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
 			usart3_rx_pb11: usart3_rx_pb11 {
-				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
 			usart3_rx_pc11: usart3_rx_pc11 {
-				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
 			usart3_rx_pd9: usart3_rx_pd9 {
-				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
 			uart4_rx_pc11: uart4_rx_pc11 {
@@ -949,31 +949,31 @@
 			/* UART_TX / USART_TX */
 
 			usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
 			usart1_tx_pb6: usart1_tx_pb6 {
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
 			usart2_tx_pa2: usart2_tx_pa2 {
-				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
 			usart2_tx_pd5: usart2_tx_pd5 {
-				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
 			usart3_tx_pb10: usart3_tx_pb10 {
-				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
 			usart3_tx_pc10: usart3_tx_pc10 {
-				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
 			usart3_tx_pd8: usart3_tx_pd8 {
-				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 
 			uart4_tx_pc10: uart4_tx_pc10 {

--- a/scripts/genpinctrl/genpinctrl.py
+++ b/scripts/genpinctrl/genpinctrl.py
@@ -176,23 +176,19 @@ def format_mode_f1(mode):
 
 
 def format_remap(remap):
-    """Format remap number for DT.
+    """Format remap value for DT.
 
     Args:
-        remap: Remap number (0..3).
+        remap: Remap definition.
 
     Returns:
         DT remap definition.
     """
 
-    if remap is None or remap == 0:
+    if remap == 0:
         return "NO_REMAP"
-    elif remap == 1:
-        return "REMAP_1"
-    elif remap == 2:
-        return "REMAP_2"
-    elif remap == 3:
-        return "REMAP_FULL"
+    elif remap is not None:
+        return remap
 
     raise ValueError(f"Unsupported remap: {remap}")
 
@@ -276,10 +272,9 @@ def get_gpio_ip_afs(data_path):
                             )
                             continue
 
-                        remap_num = int(m.group(1))
                         if signal_name not in pin_entries:
                             pin_entries[signal_name] = list()
-                        pin_entries[signal_name].append(remap_num)
+                        pin_entries[signal_name].append(name)
                 else:
                     param = signal.find(NS + "SpecificParameter")
                     if param is None:

--- a/scripts/tests/genpinctrl/data/stm32f1testdie-pinctrl.dtsi
+++ b/scripts/tests/genpinctrl/data/stm32f1testdie-pinctrl.dtsi
@@ -26,25 +26,25 @@
 			/* UART_RX / USART_RX */
 
 			uart1_rx_pa0: uart1_rx_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, UART1_REMAP1)>;
 			};
 
 			/* UART_TX / USART_TX */
 
 			uart1_tx_pa0: uart1_tx_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, UART1_REMAP0)>;
 			};
 
 			uart1_tx_pa0: uart1_tx_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_1)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, UART1_REMAP1)>;
 			};
 
 			uart1_tx_pa0: uart1_tx_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_2)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, UART1_REMAP2)>;
 			};
 
 			uart1_tx_pa0: uart1_tx_pa0 {
-				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, REMAP_FULL)>;
+				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, UART1_REMAP3)>;
 			};
 
 		};

--- a/scripts/tests/genpinctrl/test_genpinctrl.py
+++ b/scripts/tests/genpinctrl/test_genpinctrl.py
@@ -144,14 +144,11 @@ def test_format_mode_f1():
 def test_format_remap():
     """Test that format_remap works."""
 
-    assert format_remap(None) == "NO_REMAP"
+    assert format_remap("UART1_REMAP1") == "UART1_REMAP1"
     assert format_remap(0) == "NO_REMAP"
-    assert format_remap(1) == "REMAP_1"
-    assert format_remap(2) == "REMAP_2"
-    assert format_remap(3) == "REMAP_FULL"
 
     with pytest.raises(ValueError):
-        format_remap(5)
+        format_remap(None)
 
 
 def test_get_gpio_ip_afs(pindata):
@@ -169,8 +166,11 @@ def test_get_gpio_ip_afs(pindata):
         },
         "STM32F1TESTIP": {
             "PA0": {
-                "UART1_TX": [0, 1, 2, 3],
-                "UART1_RX": [1],
+                "UART1_TX": ["UART1_REMAP0",
+                             "UART1_REMAP1",
+                             "UART1_REMAP2",
+                             "UART1_REMAP3"],
+                "UART1_RX": ["UART1_REMAP1"],
             }
         },
     }
@@ -206,11 +206,11 @@ def test_get_mcu_signals(pindata):
                         "port": "a",
                         "pin": 0,
                         "signals": [
-                            {"name": "UART1_TX", "af": 0},
-                            {"name": "UART1_TX", "af": 1},
-                            {"name": "UART1_TX", "af": 2},
-                            {"name": "UART1_TX", "af": 3},
-                            {"name": "UART1_RX", "af": 1},
+                            {"name": "UART1_TX", "af": "UART1_REMAP0"},
+                            {"name": "UART1_TX", "af": "UART1_REMAP1"},
+                            {"name": "UART1_TX", "af": "UART1_REMAP2"},
+                            {"name": "UART1_TX", "af": "UART1_REMAP3"},
+                            {"name": "UART1_RX", "af": "UART1_REMAP1"},
                             {"name": "ADC1_IN0", "af": 0},
                             {"name": "I2C2_SCL", "af": 0},
                         ],


### PR DESCRIPTION
In order to simplify work on stm32f1 pinmux driver, encode more information in the remap field.
To achieve this, we only need to add peripheral name in the remap value.
For instance:
```
-				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
+				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, I2C1_REMAP0)>;
```
The remap values are directly extracted from the input .xml files ("RemapBlock Name").

`NO_REMAP` value is kept and now describe only the non "remap-able" devices.
