### PR TITLE
dts: stm32g4: Add qspi signals

### DIFF
--- a/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
@@ -281,6 +281,53 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
@@ -308,6 +308,58 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
@@ -406,6 +406,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g471meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471meyx-pinctrl.dtsi
@@ -410,6 +410,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
@@ -476,6 +476,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pf6: quadspi1_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pf7: quadspi1_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pf8: quadspi1_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
@@ -366,6 +366,73 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
@@ -422,6 +422,138 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
@@ -422,6 +422,138 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
@@ -422,6 +422,138 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
@@ -321,6 +321,53 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
@@ -348,6 +348,58 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
@@ -510,6 +510,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473meyx-pinctrl.dtsi
@@ -522,6 +522,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473p(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473p(b-c-e)ix-pinctrl.dtsi
@@ -908,6 +908,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pf6: quadspi1_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pf7: quadspi1_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pf8: quadspi1_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
@@ -956,6 +956,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pf6: quadspi1_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pf7: quadspi1_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pf8: quadspi1_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
@@ -406,6 +406,73 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
@@ -776,6 +776,138 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)ix-pinctrl.dtsi
@@ -776,6 +776,138 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
@@ -776,6 +776,138 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
@@ -403,6 +403,53 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
@@ -442,6 +442,58 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
@@ -624,6 +624,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g474meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474meyx-pinctrl.dtsi
@@ -636,6 +636,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g474p(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474p(b-c-e)ix-pinctrl.dtsi
@@ -1022,6 +1022,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pf6: quadspi1_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pf7: quadspi1_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pf8: quadspi1_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
@@ -1070,6 +1070,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pf6: quadspi1_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pf7: quadspi1_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pf8: quadspi1_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
@@ -520,6 +520,73 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
@@ -890,6 +890,138 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g474v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)ix-pinctrl.dtsi
@@ -890,6 +890,138 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
@@ -890,6 +890,138 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g483cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483cetx-pinctrl.dtsi
@@ -321,6 +321,53 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g483ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483ceux-pinctrl.dtsi
@@ -348,6 +348,58 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g483metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483metx-pinctrl.dtsi
@@ -510,6 +510,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g483meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483meyx-pinctrl.dtsi
@@ -522,6 +522,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g483peix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483peix-pinctrl.dtsi
@@ -908,6 +908,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pf6: quadspi1_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pf7: quadspi1_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pf8: quadspi1_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g483qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483qetx-pinctrl.dtsi
@@ -956,6 +956,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pf6: quadspi1_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pf7: quadspi1_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pf8: quadspi1_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g483retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483retx-pinctrl.dtsi
@@ -406,6 +406,73 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g483vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vehx-pinctrl.dtsi
@@ -776,6 +776,138 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g483veix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483veix-pinctrl.dtsi
@@ -776,6 +776,138 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g483vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vetx-pinctrl.dtsi
@@ -776,6 +776,138 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g484cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484cetx-pinctrl.dtsi
@@ -403,6 +403,53 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g484ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484ceux-pinctrl.dtsi
@@ -442,6 +442,58 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g484metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484metx-pinctrl.dtsi
@@ -624,6 +624,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g484meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484meyx-pinctrl.dtsi
@@ -636,6 +636,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g484peix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484peix-pinctrl.dtsi
@@ -1022,6 +1022,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pf6: quadspi1_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pf7: quadspi1_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pf8: quadspi1_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g484qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484qetx-pinctrl.dtsi
@@ -1070,6 +1070,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pf6: quadspi1_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pf7: quadspi1_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pf8: quadspi1_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g484retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484retx-pinctrl.dtsi
@@ -520,6 +520,73 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g484vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vehx-pinctrl.dtsi
@@ -890,6 +890,138 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g484veix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484veix-pinctrl.dtsi
@@ -890,6 +890,138 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g484vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vetx-pinctrl.dtsi
@@ -890,6 +890,138 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g491c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491c(c-e)tx-pinctrl.dtsi
@@ -269,6 +269,53 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g491c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491c(c-e)ux-pinctrl.dtsi
@@ -290,6 +290,58 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g491k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491k(c-e)ux-pinctrl.dtsi
@@ -202,6 +202,33 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g491m(c-e)sx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491m(c-e)sx-pinctrl.dtsi
@@ -382,6 +382,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g491m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491m(c-e)tx-pinctrl.dtsi
@@ -382,6 +382,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g491r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491r(c-e)ix-pinctrl.dtsi
@@ -342,6 +342,73 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g491r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491r(c-e)tx-pinctrl.dtsi
@@ -342,6 +342,73 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g491reyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491reyx-pinctrl.dtsi
@@ -342,6 +342,73 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g491v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491v(c-e)tx-pinctrl.dtsi
@@ -398,6 +398,138 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g4a1cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1cetx-pinctrl.dtsi
@@ -269,6 +269,53 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g4a1ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1ceux-pinctrl.dtsi
@@ -290,6 +290,58 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g4a1keux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1keux-pinctrl.dtsi
@@ -202,6 +202,33 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g4a1mesx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1mesx-pinctrl.dtsi
@@ -382,6 +382,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g4a1metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1metx-pinctrl.dtsi
@@ -382,6 +382,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g4a1reix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1reix-pinctrl.dtsi
@@ -342,6 +342,73 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g4a1retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1retx-pinctrl.dtsi
@@ -342,6 +342,73 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g4a1reyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1reyx-pinctrl.dtsi
@@ -342,6 +342,73 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/g4/stm32g4a1vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1vetx-pinctrl.dtsi
@@ -398,6 +398,138 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi1_bk1_ncs_pa2: quadspi1_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pa3: quadspi1_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pa6: quadspi1_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pa7: quadspi1_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pb0: quadspi1_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pb1: quadspi1_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pb2: quadspi1_bk2_io1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pb10: quadspi1_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pb11: quadspi1_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pc1: quadspi1_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pc2: quadspi1_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pc3: quadspi1_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pc4: quadspi1_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_ncs_pd3: quadspi1_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io0_pd4: quadspi1_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io1_pd5: quadspi1_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io2_pd6: quadspi1_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk2_io3_pd7: quadspi1_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pe10: quadspi1_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_ncs_pe11: quadspi1_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io0_pe12: quadspi1_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pe13: quadspi1_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io2_pe14: quadspi1_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io3_pe15: quadspi1_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_bk1_io1_pf9: quadspi1_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi1_clk_pf10: quadspi1_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -170,7 +170,7 @@
   match: "^I2S\\d+_SD$"
 
 - name: QUADSPI
-  match: "^QUADSPI_(?:CLK|NCS|BK1_NCS|BK1_IO[0-3]|BK2_NCS|BK2_IO[0-3])$"
+  match: "^QUADSPI(\\d+)?_(?:CLK|NCS|BK1_NCS|BK1_IO[0-3]|BK2_NCS|BK2_IO[0-3])$"
   slew-rate: very-high-speed
 
 - name: SDMMC


### PR DESCRIPTION
- Allow instance number in quaspi signal searches
- Provide quadspi signals on G4 series